### PR TITLE
url paramter default to scrapinghub api url, not required anymore and added .gitignore

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,17 @@ The ``scrapinghub`` module is a Python library for communicating with the
 First, you connect to Scrapinghub::
 
     >>> from scrapinghub import Connection
-    >>> conn = Connection('http://panel.scrapinghub.com/api/', 'user', 'password')
+    >>> conn = Connection('user', 'password')
     >>> conn
     Connection(http://panel.scrapinghub.com/api/)
+
+or::
+
+    >>> from scrapinghub import Connection
+    >>> conn = Connection('user', 'password', url='http://mypanel.scrapinghub.com/api/')
+    >>> conn
+    Connection(http://mypanel.scrapinghub.com/api/)
+
 
 You can list the projects available to your account::
 

--- a/scrapinghub.py
+++ b/scrapinghub.py
@@ -32,8 +32,10 @@ class Connection(object):
         'spiders': 'spiders/list'
     }
 
-    def __init__(self, url, username_or_apikey, password=''):
-        self.url = url
+    SCRAPINGHUB_API_URL = 'http://panel.scrapinghub.com/api/'
+
+    def __init__(self, username_or_apikey, password='', url=None):
+        self.url = url or self.SCRAPINGHUB_API_URL
         self._request_headers = {'User-Agent': 'scrapinghub/1.0'}
         self._set_auth(username_or_apikey, password)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -34,7 +34,7 @@ class MockResponse(object):
 class ConnectionTest(unittest.TestCase):
 
     def setUp(self):
-        self.client = Connection('http://server/api/', 'john', 'doe')
+        self.client = Connection('john', 'doe', url='http://server/api/')
 
     def test_initialization(self):
         self.assertEqual(self.client.url, 'http://server/api/')
@@ -54,7 +54,7 @@ class ConnectionTest(unittest.TestCase):
 class ProjectTest(unittest.TestCase):
 
     def setUp(self):
-        self.client = Connection('http://server/api/', 'john', 'doe')
+        self.client = Connection('john', 'doe', url='http://server/api/')
 
     def test_project_access(self):
         p1 = self.client['foo']


### PR DESCRIPTION
I remove the need to put always the scrapinghub API url and make the url parameter default to 'http://panel.scrapinghub.com/api/'. Also I've added a dot gitignore.
