### PR TITLE
Scrapinghub API URL fixed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,5 +106,5 @@ To delete several jobs (``JobSet`` also supports the ``update()`` method)::
 
     >>> project.jobs(state='finished').delete()
 
-.. _Scrapinghub API: http://panel.scrapinghub.com/help/api.html
+.. _Scrapinghub API: http://doc.scrapinghub.com/api.html
 .. _Requests: http://docs.python-requests.org/


### PR DESCRIPTION
Just an update with the correct Scrapinghub API URL, to warm up the account :smile: 