### PR TITLE
added: Retry on `httplib.HTTPException`

### DIFF
--- a/scrapinghub.py
+++ b/scrapinghub.py
@@ -10,6 +10,13 @@ import socket
 import time
 import warnings
 
+try:
+    # For Python 2
+    import httplib
+except ImportError:
+    # For Python 3
+    import http.client as httplib
+
 #python2 and python3 compatibility
 try:
     range = xrange
@@ -336,7 +343,7 @@ class Job(RequestProxyMixin):
                     yield item
                     retrieved += 1
                 break
-            except (ValueError, socket.error, requests.RequestException) as exc:
+            except (ValueError, socket.error, requests.RequestException, httplib.HTTPException) as exc:
                 lastexc = exc
                 params['offset'] += retrieved
                 if 'count' in params:


### PR DESCRIPTION
Sometimes a `httplib` exception may occur:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "dash_job_management.py", line 38, in data_export_process_job
    for item in job.items():
  File "build/bdist.linux-x86_64/egg/scrapinghub.py", line 335, in items
    for item in self._get('items', 'jl', params=params):
  File "build/bdist.linux-x86_64/egg/scrapinghub.py", line 149, in <genexpr>
    return (json.loads(line.decode('utf-8')) for line in response.iter_lines())
  File "/usr/lib/python2.7/site-packages/requests/models.py", line 715, in iter_lines
    for chunk in self.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode):
  File "/usr/lib/python2.7/site-packages/requests/models.py", line 673, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "/usr/lib/python2.7/site-packages/requests/packages/urllib3/response.py", line 304, in stream
    for line in self.read_chunked(amt):
  File "/usr/lib/python2.7/site-packages/requests/packages/urllib3/response.py", line 420, in read_chunked
    value = self._fp._safe_read(amt)
  File "/usr/lib/python2.7/httplib.py", line 666, in _safe_read
    raise IncompleteRead(''.join(s), amt)
IncompleteRead: IncompleteRead(503 bytes read, 9 more expected)
```
And I think these kinds of exceptions shall be retried as well.