### PR TITLE
Add the 'run' endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ And select a particular project to work with::
 
 To schedule a spider run (it returns the job id)::
 
-    >>> project.schedule('myspider', arg1='val1')
+    >>> project.run('myspider', arg1='val1')
     u'123/1/1'
 
 To get the list of spiders in the project::

--- a/scrapinghub.py
+++ b/scrapinghub.py
@@ -48,7 +48,8 @@ class Connection(object):
         'eggs_list': 'eggs/list',
         'as_project_slybot': 'as/project-slybot',
         'as_spider_properties': 'as/spider-properties',
-        'schedule': 'schedule',
+        'run': 'run',
+        'schedule': 'schedule',  # Deprecated, use 'run' instead
         'items': 'items',
         'log': 'log',
         'spiders': 'spiders/list',
@@ -204,7 +205,14 @@ class Project(RequestProxyMixin):
         warnings.warn("Project.name is deprecated, use Project.id instead", stacklevel=2)
         return self.id
 
+    def run(self, spider, **params):
+        params['spider'] = spider
+        result = self._post('run', 'json', params)
+        return result['jobid']
+
     def schedule(self, spider, **params):
+        warnings.warn("Project.schedule() method is deprecated, "
+                      "use Project.run() method instead", stacklevel=2)
         params['spider'] = spider
         result = self._post('schedule', 'json', params)
         return result['jobid']


### PR DESCRIPTION
Deprecate the 'schedule' endpoint in favor of the new 'run' endpoint.
