### PR TITLE
Fix ResourceType._allows_mpack check.

### DIFF
--- a/scrapinghub/hubstorage/resourcetype.py
+++ b/scrapinghub/hubstorage/resourcetype.py
@@ -23,16 +23,22 @@ class ResourceType(object):
         self.url = urlpathjoin(client.endpoint, self.key)
 
     def _allows_mpack(self, path=None):
-        """ Check if request can be served with msgpack data.
+        """Check if request can be served with msgpack data.
 
-        Currently, items, logs, collections and samples endpoints are able to
+        Currently, items, logs and samples endpoints are able to
         return msgpack data. However, /stats calls can only return JSON data
         for now.
+
+        :param path: None, tuple or string
+
         """
-        if not MSGPACK_AVAILABLE or path == 'stats':
+        if not MSGPACK_AVAILABLE:
             return False
-        return self.resource_type in ('items', 'logs',
-                                      'collections', 'samples')
+        path = urlpathjoin(path or '')
+        return (
+            self.resource_type in ('items', 'logs', 'samples') and
+            not path.rstrip('/').endswith('stats')
+        )
 
     @staticmethod
     def _enforce_msgpack(**kwargs):

--- a/tests/hubstorage/hstestcase.py
+++ b/tests/hubstorage/hstestcase.py
@@ -2,8 +2,9 @@ import os
 import unittest
 import random
 import requests
-from hubstorage import HubstorageClient
-from hubstorage.utils import urlpathjoin
+
+from scrapinghub import HubstorageClient
+from scrapinghub.hubstorage.utils import urlpathjoin
 
 
 class HSTestCase(unittest.TestCase):

--- a/tests/hubstorage/test_batchuploader.py
+++ b/tests/hubstorage/test_batchuploader.py
@@ -5,7 +5,8 @@ import time
 from six.moves import range
 from collections import defaultdict
 from .hstestcase import HSTestCase
-from hubstorage import ValueTooLarge
+
+from scrapinghub.hubstorage import ValueTooLarge
 
 
 class BatchUploaderTest(HSTestCase):

--- a/tests/hubstorage/test_client.py
+++ b/tests/hubstorage/test_client.py
@@ -2,8 +2,8 @@
 Test Client
 """
 from .hstestcase import HSTestCase
-from hubstorage import HubstorageClient
-from hubstorage.utils import apipoll
+from scrapinghub import HubstorageClient
+from scrapinghub.hubstorage.utils import apipoll
 
 class ClientTest(HSTestCase):
 

--- a/tests/hubstorage/test_jobq.py
+++ b/tests/hubstorage/test_jobq.py
@@ -2,10 +2,13 @@
 Test JobQ
 """
 import os, unittest
+
 import six
 from six.moves import range
-from hubstorage.jobq import DuplicateJobError
-from hubstorage.utils import apipoll
+
+from scrapinghub.hubstorage.jobq import DuplicateJobError
+from scrapinghub.hubstorage.utils import apipoll
+
 from .hstestcase import HSTestCase
 
 

--- a/tests/hubstorage/test_retry.py
+++ b/tests/hubstorage/test_retry.py
@@ -1,13 +1,15 @@
 """
 Test Retry Policy
 """
-from six.moves.http_client import BadStatusLine
-from requests import HTTPError, ConnectionError
-from .hstestcase import HSTestCase
-from hubstorage import HubstorageClient
-import responses
 import json
 import re
+
+import responses
+from requests import HTTPError, ConnectionError
+from scrapinghub import HubstorageClient
+from six.moves.http_client import BadStatusLine
+
+from .hstestcase import HSTestCase
 
 GET = responses.GET
 POST = responses.POST

--- a/tests/hubstorage/test_system.py
+++ b/tests/hubstorage/test_system.py
@@ -1,9 +1,12 @@
 import random
-from six.moves import range
 from contextlib import closing
+
+from six.moves import range
+
+from scrapinghub import HubstorageClient
+from scrapinghub.hubstorage.utils import millitime
+
 from .hstestcase import HSTestCase
-from hubstorage import HubstorageClient
-from hubstorage.utils import millitime
 
 
 class SystemTest(HSTestCase):


### PR DESCRIPTION
Existing check is broken. It works for items, logs and samples only if one uses them through Job object. However it doesn't work correctly for `list(proj.items.apiget('33/5/stats'))`). Also for collections it applies the same rules as for items, but only few collections endpoints support msgpack - scan, batch scan and get collection item. Other endpoints do no support msgpack.