### PR TITLE
Replace Cyrillic character in code sample

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ The library can also be used for interaction with spiders, jobs and scraped data
 First, use your API key for authorization::
 
     >>> from scrapinghub import HubstorageClient
-    >>> hс = HubstorageClient(auth='apikey')
+    >>> hc = HubstorageClient(auth='apikey')
     >>> hc.server_timestamp()
     1446222762611
 


### PR DESCRIPTION
There was a Cyrillic letter, very similar to `c`, in one of the README's samples that causes a `SyntaxError: invalid syntax` error when running the code.