### PR TITLE
Enforce a dot before .devN release suffix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    condition: $TOXENV == py27 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|dev[0-9]+)?$
+    condition: $TOXENV == py27 && $TRAVIS_TAG =~ ^[0-9]+[.][0-9]+[.][0-9]+(rc[0-9]+|[.]dev[0-9]+)?$
   user: scrapinghub
   password:
     secure: SMPghJT7GScj6jQBimk8r58vRNfbKQQkXvfh5DJC38d0XeNtpBJQ750LT7Zlw8R+qAadT8sA7M1YYZY8mIQgdakQv48zX7EVxyc/8a2rAOF9p/ikRn0Dc50Qzr9U5Rtbsp7PMYlmUyeo9VjrStPPkHUPW2Q7vprTpdFrlDaf3WA=


### PR DESCRIPTION
A fix similar to https://github.com/scrapy/scrapy/pull/2470.