### PR TITLE
Add type field to APIError for better matching errors

### DIFF
--- a/scrapinghub/exceptions.py
+++ b/scrapinghub/exceptions.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 from requests import HTTPError
 
+from .legacy import APIError
 from .hubstorage import ValueTooLarge as _ValueTooLarge
 
 
@@ -62,6 +63,15 @@ def wrap_http_errors(method):
             elif 400 <= status_code < 500:
                 raise ScrapinghubAPIError(http_error=exc)
             raise
+        except APIError as exc:
+            msg = exc.args[0]
+            if exc._type == APIError.ERR_NOT_FOUND:
+                raise NotFound(msg)
+            elif exc._type == APIError.ERR_VALUE_ERROR:
+                raise ValueError(msg)
+            elif exc._type == APIError.ERR_INVALID_USAGE:
+                raise InvalidUsage(msg)
+            raise ScrapinghubAPIError(msg)
     return wrapped
 
 


### PR DESCRIPTION
Raised by [the comment](https://github.com/scrapinghub/python-scrapinghub/pull/38#discussion_r98424409), should simplify matching and handling exceptions by type in the new python client. Review, please.