### PR TITLE
Improvements and fixes for new python client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ And select a particular project to work with::
     >>> project = client.get_project(123)
     >>> project
     <scrapinghub.client.Project at 0x106cdd6a0>
-    >>> project.id
-    123
+    >>> project.key
+    '123'
 
 The above is a shortcut for ``client.projects.get(123)``.
 
@@ -116,8 +116,8 @@ To select a particular spider to work with::
     >>> spider = project.spiders.get('spider2')
     >>> spider
     <scrapinghub.client.Spider at 0x106ee3748>
-    >>> spider.id
-    2
+    >>> spider.key
+    '123/2'
     >>> spider.name
     spider2
 
@@ -144,7 +144,7 @@ get
 To select a specific job for a project::
 
     >>> job = project.jobs.get('123/1/2')
-    >>> job.id
+    >>> job.key
     '123/1/2'
 
 Also there's a shortcut to get same job with client instance::

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Jobs instance is described well in ``Jobs`` section below.
 
 For example, to schedule a spider run (it returns a job object)::
 
-    >>> project.jobs.schedule('spider1', arg1='val1')
+    >>> project.jobs.schedule('spider1', spider_args={'arg1':'val1'})
     <scrapinghub.client.Job at 0x106ee12e8>>
 
 Project instance also has the following fields:
@@ -128,7 +128,7 @@ Like project instance, spider instance has ``jobs`` field to work with the spide
 
 To schedule a spider run::
 
-    >>> spider.jobs.schedule(arg1='val1')
+    >>> spider.jobs.schedule(spider_args={'arg1:'val1'})
     <scrapinghub.client.Job at 0x106ee12e8>>
 
 Note that you don't need to specify spider name explicitly.
@@ -160,6 +160,7 @@ Use ``schedule`` method to schedule a new job for project/spider::
 
 Scheduling logic supports different options, like
 
+- spider_args to provide spider arguments for the job
 - units to specify amount of units to schedule the job
 - job_settings to pass additional settings for the job
 - priority to set higher/lower priority of the job

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --doctest-modules --doctest-glob='scrapinghub/*.py'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules --doctest-glob='scrapinghub/*.py'
+addopts = --doctest-glob='scrapinghub/*.py'

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -1018,3 +1018,10 @@ class Collection(object):
         if key is None:
             raise ValueError("key cannot be None")
         return self._origin.get(key, *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        """Set item to collection by key.
+
+        The method returns None (original method returns an empty generator).
+        """
+        self._origin.set(*args, **kwargs)

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -1,5 +1,7 @@
 import json
 
+from six import string_types
+
 from scrapinghub import APIError
 from scrapinghub import Connection as _Connection
 from scrapinghub import HubstorageClient as _HubstorageClient
@@ -1092,7 +1094,7 @@ class Collection(object):
         self._client = client
         self._origin = _Collection(coltype, colname, collections._origin)
         proxy_methods(self._origin, self, [
-            'create_writer', 'delete', 'count',
+            'create_writer', 'count',
             ('iter', 'iter_values'),
             ('iter_raw_json', 'iter_json'),
         ])
@@ -1127,3 +1129,15 @@ class Collection(object):
         The method returns None (original method returns an empty generator).
         """
         self._origin.set(*args, **kwargs)
+
+    def delete(self, _keys):
+        """Delete item(s) from collection by key(s).
+
+        The method returns None (original method returns an empty generator).
+        """
+        if (not isinstance(_keys, string_types) and
+                not(isinstance(_keys, (list, tuple)) and
+                    all(isinstance(key, string_types) for key in _keys))):
+            raise ValueError(
+                "You should provide a string key or a list of string keys")
+        self._origin.delete(_keys)

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -457,6 +457,13 @@ class Jobs(object):
             raise ValueError('Please provide spidername')
         params['project'] = self.projectid
         params['spider'] = spidername or self.spider.name
+        spider_args = params.pop('spider_args', None)
+        if spider_args:
+            if not isinstance(spider_args, dict):
+                raise ValueError("spider_args should be a dictionary")
+            cleaned_args = {k: v for k, v in spider_args.items()
+                            if k not in params}
+            params.update(cleaned_args)
         if 'job_settings' in params:
             params['job_settings'] = json.dumps(params['job_settings'])
         if 'meta' in params:

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -736,7 +736,8 @@ class _Proxy(object):
             setattr(self, 'write', wrap_value_too_large(origin_method))
 
         # DType iter_values() has more priority than IType list()
-        if issubclass(cls, DownloadableResource):
+        # plus Collections interface doesn't need the iter methods
+        if issubclass(cls, DownloadableResource) and cls is not Collections:
             methods = [('iter', 'iter_values'),
                        ('iter_raw_msgpack', 'iter_msgpack'),
                        ('iter_raw_json', 'iter_json')]
@@ -975,6 +976,8 @@ class Collections(_Proxy):
     Usage::
 
         >>> collections = project.collections
+        >>> collections.list()
+        [{'name': 'Pages', 'type': 's'}]
         >>> foo_store = collections.get_store('foo_store')
     """
 
@@ -994,6 +997,9 @@ class Collections(_Proxy):
 
     def get_versioned_cached_store(self, colname):
         return self.get('vcs', colname)
+
+    def list(self):
+        return list(self._origin.apiget('list'))
 
 
 class Collection(object):

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -1147,13 +1147,13 @@ class Collection(object):
         """
         self._origin.set(*args, **kwargs)
 
-    def delete(self, _keys):
+    def delete(self, keys):
         """Delete item(s) from collection by key(s).
 
         The method returns None (original method returns an empty generator).
         """
-        if (not isinstance(_keys, string_types) and
-                not isinstance(_keys, collections.Iterable)):
+        if (not isinstance(keys, string_types) and
+                not isinstance(keys, collections.Iterable)):
             raise ValueError("You should provide string key or iterable "
                              "object providing string keys")
-        self._origin.delete(_keys)
+        self._origin.delete(keys)

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -286,7 +286,7 @@ class Spider(object):
         >>> project.spiders.get('spider2')
         <scrapinghub.client.Spider at 0x106ee3748>
         >>> spider.key
-        2
+        1
         >>> spider.name
         spider2
     """
@@ -1042,7 +1042,7 @@ class Collection(object):
         self._client = client
         self._origin = _Collection(coltype, colname, collections._origin)
         proxy_methods(self._origin, self, [
-            'create_writer', 'get', 'set', 'delete', 'count',
+            'create_writer', 'delete', 'count',
             ('iter', 'iter_values'),
             ('iter_raw_json', 'iter_json'),
         ])

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -200,7 +200,7 @@ class Project(object):
     """
 
     def __init__(self, client, projectid):
-        self.id = projectid
+        self.key = projectid
         self._client = client
 
         # sub-resources
@@ -284,7 +284,7 @@ class Spider(object):
 
         >>> project.spiders.get('spider2')
         <scrapinghub.client.Spider at 0x106ee3748>
-        >>> spider.id
+        >>> spider.key
         2
         >>> spider.name
         spider2
@@ -292,7 +292,7 @@ class Spider(object):
 
     def __init__(self, client, projectid, spiderid, spidername):
         self.projectid = projectid
-        self.id = spiderid
+        self.key = spiderid
         self.name = spidername
         self.jobs = Jobs(client, projectid, self)
         self._client = client
@@ -435,13 +435,13 @@ class Jobs(object):
         Usage::
 
             >>> job = project.jobs.get('123/1/2')
-            >>> job.id
+            >>> job.key
             '123/1/2'
         """
         jobkey = parse_job_key(jobkey)
         if jobkey.projectid != self.projectid:
             raise ValueError('Please use same project id')
-        if self.spider and jobkey.spiderid != self.spider.id:
+        if self.spider and jobkey.spiderid != self.spider.key:
             raise ValueError('Please use same spider id')
         return Job(self._client, str(jobkey))
 
@@ -503,8 +503,8 @@ class Jobs(object):
     def _extract_spider_id(self, params):
         spiderid = params.pop('spiderid', None)
         if not spiderid and self.spider:
-            return self.spider.id
-        elif spiderid and self.spider and spiderid != self.spider.id:
+            return self.spider.key
+        elif spiderid and self.spider and spiderid != self.spider.key:
             raise ValueError('Please use same spider id')
         return spiderid
 
@@ -563,7 +563,7 @@ class Job(object):
     Usage::
 
         >>> job = project.job('123/1/2')
-        >>> job.id
+        >>> job.key
         '123/1/2'
         >>> job.metadata['state']
         'finished'

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -11,7 +11,6 @@ from .hubstorage.resourcetype import DownloadableResource
 from .hubstorage.resourcetype import ItemsResourceType
 
 # scrapinghub.hubstorage classes to use as-is
-from .hubstorage.frontier import Frontier
 from .hubstorage.job import JobMeta
 from .hubstorage.project import Settings
 
@@ -19,6 +18,7 @@ from .hubstorage.project import Settings
 from .hubstorage.activity import Activity as _Activity
 from .hubstorage.collectionsrt import Collections as _Collections
 from .hubstorage.collectionsrt import Collection as _Collection
+from .hubstorage.frontier import Frontier as _Frontier
 from .hubstorage.job import Items as _Items
 from .hubstorage.job import Logs as _Logs
 from .hubstorage.job import Samples as _Samples
@@ -227,7 +227,7 @@ class Project(object):
         # proxied sub-resources
         self.activity = Activity(_Activity, client, projectid)
         self.collections = Collections(_Collections, client, projectid)
-        self.frontier = Frontier(client._hsclient, projectid)
+        self.frontier = Frontier(_Frontier, client, projectid)
         self.settings = Settings(client._hsclient, projectid)
 
 
@@ -1082,6 +1082,31 @@ class Collections(_Proxy):
     def list(self):
         """List collections of a project."""
         return list(self.iter())
+
+
+class Frontier(_Proxy):
+    """Frontiers collection for a project."""
+
+    def __init__(self, *args, **kwargs):
+        super(Frontier, self).__init__(*args, **kwargs)
+        self._proxy_methods(['close', 'flush', 'add', 'read', 'delete',
+                             'delete_slot'])
+
+    @property
+    def newcount(self):
+        return self._origin.newcount
+
+    def iter(self):
+        return iter(self.list())
+
+    def list(self):
+        return next(self._origin.apiget('list'))
+
+    def iter_slots(self, name):
+        return iter(self.list_slots(name))
+
+    def list_slots(self, name):
+        return next(self._origin.apiget((name, 'list')))
 
 
 class Collection(object):

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -1,6 +1,7 @@
 import json
 
 from six import string_types
+from requests.compat import urljoin
 
 from scrapinghub import APIError
 from scrapinghub import Connection as _Connection
@@ -304,6 +305,16 @@ class Spider(object):
         self.name = spidername
         self.jobs = Jobs(client, projectid, self)
         self._client = client
+
+    @wrap_http_errors
+    def update_tags(self, add=None, remove=None):
+        params = get_tags_for_update(add=add, remove=remove)
+        if not params:
+            return
+        path = 'v2/projects/{}/spiders/{}/tags'.format(self.projectid, self.id)
+        url = urljoin(self._client._connection.url, path)
+        response = self._client._connection._session.patch(url, json=params)
+        response.raise_for_status()
 
 
 class Jobs(object):

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -956,10 +956,14 @@ class Activity(_Proxy):
         self._proxy_methods([('iter', 'list')])
 
     def add(self, *args, **kwargs):
-        self._origin.add(*args, **kwargs)
+        entry = dict(*args, **kwargs)
+        return self.post(entry)
 
-    def post(self, *args, **kwargs):
-        self._origin.post(*args, **kwargs)
+    def post(self, _value, **kwargs):
+        jobkey = _value.get('job') or kwargs.get('job')
+        if jobkey and parse_job_key(jobkey).projectid != self.key:
+            raise ValueError('Please use same project id')
+        self._origin.post(_value, **kwargs)
 
 
 class Collections(_Proxy):

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -200,10 +200,12 @@ class Project(object):
         >>> project = client.get_project(123)
         >>> project
         <scrapinghub.client.Project at 0x106cdd6a0>
+        >>> project.key
+        '123'
     """
 
     def __init__(self, client, projectid):
-        self.key = projectid
+        self.key = str(projectid)
         self._client = client
 
         # sub-resources
@@ -287,15 +289,18 @@ class Spider(object):
 
         >>> spider = project.spiders.get('spider1')
         <scrapinghub.client.Spider at 0x106ee3748>
-        >>> spider.key
+        >>> spider.id
         '1'
+        >>> spider.key
+        '123/1'
         >>> spider.name
         'spider1'
     """
 
     def __init__(self, client, projectid, spiderid, spidername):
         self.projectid = projectid
-        self.key = str(spiderid)
+        self.key = '{}/{}'.format(str(projectid), str(spiderid))
+        self.id = str(spiderid)
         self.name = spidername
         self.jobs = Jobs(client, projectid, self)
         self._client = client
@@ -455,7 +460,7 @@ class Jobs(object):
         jobkey = parse_job_key(jobkey)
         if jobkey.projectid != self.projectid:
             raise ValueError('Please use same project id')
-        if self.spider and jobkey.spiderid != self.spider.key:
+        if self.spider and jobkey.spiderid != self.spider.id:
             raise ValueError('Please use same spider id')
         return Job(self._client, str(jobkey))
 
@@ -517,10 +522,10 @@ class Jobs(object):
     def _extract_spider_id(self, params):
         spiderid = params.pop('spiderid', None)
         if not spiderid and self.spider:
-            return self.spider.key
-        elif spiderid and self.spider and spiderid != self.spider.key:
+            return self.spider.id
+        elif spiderid and self.spider and str(spiderid) != self.spider.id:
             raise ValueError('Please use same spider id')
-        return spiderid
+        return str(spiderid)
 
     def update_tags(self, add=None, remove=None, spidername=None):
         """Update tags for all existing spider jobs.

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -549,6 +549,8 @@ class Jobs(object):
             ...     remove=['existing'], spidername='spider2')
             2
         """
+        if not (add or remove):
+            raise ValueError('Please provide tags to add or remove')
         spidername = spidername or (self.spider.name if self.spider else None)
         if not spidername:
             raise ValueError('Please provide spidername')
@@ -630,6 +632,8 @@ class Job(object):
 
             >>> job.update_tags(add=['consumed'])
         """
+        if not (add or remove):
+            raise ValueError('Please provide tags to add or remove')
         params = get_tags_for_update(add_tag=add, remove_tag=remove)
         if not params:
             return

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -29,6 +29,7 @@ from .exceptions import wrap_http_errors, wrap_value_too_large
 
 from .utils import LogLevel
 from .utils import get_tags_for_update
+from .utils import parse_auth
 from .utils import parse_project_id, parse_job_key
 from .utils import proxy_methods
 from .utils import wrap_kwargs
@@ -52,7 +53,7 @@ class HubstorageClient(_HubstorageClient):
 class ScrapinghubClient(object):
     """Main class to work with Scrapinghub API.
 
-    :param apikey: Scrapinghub APIKEY string.
+    :param auth: Scrapinghub APIKEY or other SH auth credentials.
     :param dash_endpoint: (optional) Scrapinghub Dash panel url.
     :param \*\*kwargs: (optional) Additional arguments for
         :class:`scrapinghub.hubstorage.HubstorageClient` constructor.
@@ -67,10 +68,15 @@ class ScrapinghubClient(object):
         <scrapinghub.client.ScrapinghubClient at 0x1047af2e8>
     """
 
-    def __init__(self, apikey=None, dash_endpoint=None, **kwargs):
+    def __init__(self, auth=None, dash_endpoint=None, **kwargs):
         self.projects = Projects(self)
-        self._connection = Connection(apikey=apikey, url=dash_endpoint)
-        self._hsclient = HubstorageClient(auth=apikey, **kwargs)
+        auth = parse_auth(auth)
+        connection_kwargs = {'apikey': auth, 'url': dash_endpoint}
+        if len(auth) == 2:
+            connection_kwargs['apikey'] = auth[0]
+            connection_kwargs['password'] = auth[1]
+        self._connection = Connection(**connection_kwargs)
+        self._hsclient = HubstorageClient(auth=auth, **kwargs)
 
     def get_project(self, projectid):
         """Get :class:`Project` instance with a given project id.

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -70,13 +70,11 @@ class ScrapinghubClient(object):
 
     def __init__(self, auth=None, dash_endpoint=None, **kwargs):
         self.projects = Projects(self)
-        auth = parse_auth(auth)
-        connection_kwargs = {'apikey': auth, 'url': dash_endpoint}
-        if len(auth) == 2:
-            connection_kwargs['apikey'] = auth[0]
-            connection_kwargs['password'] = auth[1]
-        self._connection = Connection(**connection_kwargs)
-        self._hsclient = HubstorageClient(auth=auth, **kwargs)
+        login, password = parse_auth(auth)
+        self._connection = Connection(apikey=login,
+                                      password=password,
+                                      url=dash_endpoint)
+        self._hsclient = HubstorageClient(auth=(login, password), **kwargs)
 
     def get_project(self, projectid):
         """Get :class:`Project` instance with a given project id.

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -157,6 +157,13 @@ class Projects(object):
         """
         return self._client._connection.project_ids()
 
+    def iter(self):
+        """Iterate through list of projects available to current user.
+
+        Provided for the sake of API consistency.
+        """
+        return iter(self.list())
+
     def summary(self, **params):
         """Get short summaries for all available user projects.
 
@@ -273,6 +280,13 @@ class Spiders(object):
         """
         project = self._client._connection[self.projectid]
         return project.spiders()
+
+    def iter(self):
+        """Iterate through a list of spiders for a project.
+
+        Provided for the sake of API consistency.
+        """
+        return iter(self.list())
 
 
 class Spider(object):
@@ -1057,8 +1071,13 @@ class Collections(_Proxy):
     def get_versioned_cached_store(self, colname):
         return self.get('vcs', colname)
 
+    def iter(self):
+        """Iterate through collections of a project."""
+        return self._origin.apiget('list')
+
     def list(self):
-        return list(self._origin.apiget('list'))
+        """List collections of a project."""
+        return list(self.iter())
 
 
 class Collection(object):

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -554,8 +554,6 @@ class Jobs(object):
             ...     remove=['existing'], spidername='spider2')
             2
         """
-        if not (add or remove):
-            raise ValueError('Please provide tags to add or remove')
         spidername = spidername or (self.spider.name if self.spider else None)
         if not spidername:
             raise ValueError('Please provide spidername')
@@ -637,8 +635,6 @@ class Job(object):
 
             >>> job.update_tags(add=['consumed'])
         """
-        if not (add or remove):
-            raise ValueError('Please provide tags to add or remove')
         params = get_tags_for_update(add_tag=add, remove_tag=remove)
         if not params:
             return

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -525,7 +525,7 @@ class Jobs(object):
             return self.spider.id
         elif spiderid and self.spider and str(spiderid) != self.spider.id:
             raise ValueError('Please use same spider id')
-        return str(spiderid)
+        return str(spiderid) if spiderid else None
 
     def update_tags(self, add=None, remove=None, spidername=None):
         """Update tags for all existing spider jobs.

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -293,7 +293,7 @@ class Spider(object):
 
     def __init__(self, client, projectid, spiderid, spidername):
         self.projectid = projectid
-        self.key = spiderid
+        self.key = str(spiderid)
         self.name = spidername
         self.jobs = Jobs(client, projectid, self)
         self._client = client

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -286,9 +286,9 @@ class Spider(object):
         >>> spider = project.spiders.get('spider1')
         <scrapinghub.client.Spider at 0x106ee3748>
         >>> spider.key
-        1
+        '1'
         >>> spider.name
-        spider1
+        'spider1'
     """
 
     def __init__(self, client, projectid, spiderid, spidername):

--- a/scrapinghub/client.py
+++ b/scrapinghub/client.py
@@ -96,7 +96,7 @@ class ScrapinghubClient(object):
 
         Usage::
 
-            >>> job = client.get_job('1/2/3')
+            >>> job = client.get_job('123/1/1')
             >>> job
             <scrapinghub.client.Job at 0x10afe2eb1>
         """
@@ -283,12 +283,12 @@ class Spider(object):
 
     Usage::
 
-        >>> project.spiders.get('spider2')
+        >>> spider = project.spiders.get('spider1')
         <scrapinghub.client.Spider at 0x106ee3748>
         >>> spider.key
         1
         >>> spider.name
-        spider2
+        spider1
     """
 
     def __init__(self, client, projectid, spiderid, spidername):
@@ -313,7 +313,7 @@ class Jobs(object):
 
         >>> project.jobs
         <scrapinghub.client.Jobs at 0x10477f0b8>
-        >>> spider = project.spiders.get('spider2')
+        >>> spider = project.spiders.get('spider1')
         >>> spider.jobs
         <scrapinghub.client.Jobs at 0x104767e80>
     """
@@ -333,6 +333,7 @@ class Jobs(object):
 
         Usage::
 
+            >>> spider = project.spiders.get('spider1')
             >>> spider.jobs.count()
             5
             >>> project.jobs.count(spider='spider2', state='finished')
@@ -384,7 +385,7 @@ class Jobs(object):
         - get certain number of last finished jobs per some spider::
 
             >>> jobs_summary = project.jobs.iter(
-            ...     spider='foo', state='finished', count=3)
+            ...     spider='spider2', state='finished', count=3)
         """
         if self.spider:
             params['spider'] = self.spider.name
@@ -400,7 +401,7 @@ class Jobs(object):
 
         Usage::
 
-            >>> project.schedule('myspider', arg1='val1')
+            >>> project.schedule('spider1', arg1='val1')
             '123/1/1'
         """
         if not spidername and not self.spider:
@@ -526,13 +527,14 @@ class Jobs(object):
 
         - mark all spider jobs with tag ``consumed``::
 
+            >>> spider = project.spiders.get('spider1')
             >>> spider.jobs.update_tags(add=['consumed'])
             5
 
         - remove existing tag ``existing`` for all spider jobs::
 
             >>> project.jobs.update_tags(
-            ...     remove=['existing'], spidername='spider')
+            ...     remove=['existing'], spidername='spider2')
             2
         """
         spidername = spidername or (self.spider.name if self.spider else None)

--- a/scrapinghub/exceptions.py
+++ b/scrapinghub/exceptions.py
@@ -35,7 +35,7 @@ class InvalidUsage(ScrapinghubAPIError):
     pass
 
 
-class AuthorizationError(ScrapinghubAPIError):
+class Unauthorized(ScrapinghubAPIError):
     pass
 
 
@@ -61,10 +61,7 @@ def wrap_http_errors(method):
             if status_code == 400:
                 raise InvalidUsage(http_error=exc)
             elif status_code == 401:
-                raise AuthorizationError(
-                    message='Please check your credentials.',
-                    http_error=exc,
-                )
+                raise Unauthorized(http_error=exc)
             elif status_code == 404:
                 raise NotFound(http_error=exc)
             elif status_code == 413:
@@ -80,6 +77,8 @@ def wrap_http_errors(method):
                 raise ValueError(msg)
             elif exc._type == APIError.ERR_INVALID_USAGE:
                 raise InvalidUsage(msg)
+            elif exc._type == APIError.ERR_AUTH_ERROR:
+                raise Unauthorized(http_error=exc)
             raise ScrapinghubAPIError(msg)
     return wrapped
 

--- a/scrapinghub/exceptions.py
+++ b/scrapinghub/exceptions.py
@@ -35,6 +35,10 @@ class InvalidUsage(ScrapinghubAPIError):
     pass
 
 
+class AuthorizationError(ScrapinghubAPIError):
+    pass
+
+
 class NotFound(ScrapinghubAPIError):
     pass
 
@@ -56,6 +60,11 @@ def wrap_http_errors(method):
             status_code = exc.response.status_code
             if status_code == 400:
                 raise InvalidUsage(http_error=exc)
+            elif status_code == 401:
+                raise AuthorizationError(
+                    message='Please check your credentials.',
+                    http_error=exc,
+                )
             elif status_code == 404:
                 raise NotFound(http_error=exc)
             elif status_code == 413:

--- a/scrapinghub/legacy.py
+++ b/scrapinghub/legacy.py
@@ -60,10 +60,10 @@ class Connection(object):
 
         assert not apikey.startswith('http://'), \
                 "Instantiating scrapinghub.Connection with url as first argument is not supported"
-        assert not password, \
-                "Authentication with user:pass is not supported, use your apikey instead"
-
+        if password:
+            warnings.warn("A lot of endpoints support authentication only via apikey.")
         self.apikey = apikey
+        self.password = password or ''
         self.url = url or self.DEFAULT_ENDPOINT
         self._session = self._create_session()
 
@@ -74,13 +74,13 @@ class Connection(object):
     def auth(self):
         warnings.warn("'auth' connection attribute is deprecated, "
                       "use 'apikey' attribute instead", stacklevel=2)
-        return (self.apikey, '')
+        return (self.apikey, self.password)
 
     def _create_session(self):
         from requests import session
         from scrapinghub import __version__
         s = session()
-        s.auth = (self.apikey, '')
+        s.auth = (self.apikey, self.password)
         s.headers.update({
             'User-Agent': 'python-scrapinghub/{0}'.format(__version__),
         })

--- a/scrapinghub/legacy.py
+++ b/scrapinghub/legacy.py
@@ -146,6 +146,10 @@ class Connection(object):
             try:
                 if data['status'] == 'ok':
                     return data
+                elif (data['status'] == 'error' and
+                        data['message'] == 'Authentication failed'):
+                    raise APIError(data['message'],
+                                   _type=APIError.ERR_AUTH_ERROR)
                 elif data['status'] in ('error', 'badrequest'):
                     raise APIError(data['message'],
                                    _type=APIError.ERR_INVALID_USAGE)
@@ -402,6 +406,7 @@ class APIError(Exception):
     ERR_NOT_FOUND = 1
     ERR_VALUE_ERROR = 2
     ERR_INVALID_USAGE = 3
+    ERR_AUTH_ERROR = 4
 
     def __init__(self, message, _type=None):
         super(APIError, self).__init__(message)

--- a/scrapinghub/utils.py
+++ b/scrapinghub/utils.py
@@ -151,6 +151,8 @@ def parse_auth(auth):
         decoded_auth = decode(auth, 'hex_codec')
     except (binascii.Error, TypeError):
         login, _, password = auth.partition(':')
+        if not password:
+            raise ValueError("Bad apikey, please check your credentials")
         return (login, password)
 
     try:

--- a/scrapinghub/utils.py
+++ b/scrapinghub/utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from six import string_types
@@ -83,3 +84,20 @@ def proxy_methods(origin, successor, methods):
             successor_name, origin_name = method, method
         if not hasattr(successor, successor_name):
             setattr(successor, successor_name, getattr(origin, origin_name))
+
+
+def format_iter_filters(params):
+    """Format iter() filter param on-the-fly.
+
+    Support passing multiple filters at once as a list with tuples.
+    """
+    filters = params.get('filter')
+    if filters and isinstance(filters, list):
+        filter_data = []
+        for elem in params.pop('filter'):
+            if not isinstance(elem, (list, tuple)):
+                raise ValueError("Filter condition must be tuple or list")
+            filter_data.append(json.dumps(elem))
+        if filter_data:
+            params['filter'] = filter_data
+    return params

--- a/scrapinghub/utils.py
+++ b/scrapinghub/utils.py
@@ -26,10 +26,10 @@ class JobKey(object):
 
 def parse_project_id(projectid):
     try:
-        projectid = int(projectid)
+        int(projectid)
     except ValueError:
-        raise ValueError("Project ID should be convertible to integer")
-    return projectid
+        raise ValueError("Project id should be convertible to integer")
+    return str(projectid)
 
 
 def parse_job_key(jobkey):
@@ -42,10 +42,10 @@ def parse_job_key(jobkey):
     if len(parts) != 3:
         raise ValueError("Job key should consist of projectid/spiderid/jobid")
     try:
-        parts = map(int, parts)
+        map(int, parts)
     except ValueError:
         raise ValueError("Job key parts should be integers")
-    return JobKey(*parts)
+    return JobKey(*map(str, parts))
 
 
 def get_tags_for_update(**kwargs):

--- a/scrapinghub/utils.py
+++ b/scrapinghub/utils.py
@@ -95,9 +95,13 @@ def format_iter_filters(params):
     if filters and isinstance(filters, list):
         filter_data = []
         for elem in params.pop('filter'):
-            if not isinstance(elem, (list, tuple)):
-                raise ValueError("Filter condition must be tuple or list")
-            filter_data.append(json.dumps(elem))
+            if isinstance(elem, string_types):
+                filter_data.append(elem)
+            elif isinstance(elem, (list, tuple)):
+                filter_data.append(json.dumps(elem))
+            else:
+                raise ValueError(
+                    "Filter condition must be string, tuple or list")
         if filter_data:
             params['filter'] = filter_data
     return params

--- a/scrapinghub/utils.py
+++ b/scrapinghub/utils.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import binascii
 
+from codecs import decode
 from six import string_types
 
 
@@ -105,3 +107,28 @@ def format_iter_filters(params):
         if filter_data:
             params['filter'] = filter_data
     return params
+
+
+def parse_auth(auth):
+    """Parse authentification token.
+
+    >>> parse_auth(None)
+    >>> parse_auth(('user', 'pass'))
+    ('user', 'pass')
+    >>> parse_auth('user:pass')
+    ('user', 'pass')
+    >>> parse_auth('apikey')
+    ('apikey', '')
+    >>> parse_auth('312f322f333a736f6d652e6a77742e746f6b656e')
+    ('1/2/3', 'some.jwt.token')
+    """
+    if auth is None or isinstance(auth, tuple):
+        return auth
+    try:
+        auth = decode(auth, 'hex_codec')
+        if not isinstance(auth, string_types):
+            auth = auth.decode('ascii')
+    except binascii.Error:
+        pass
+    user, _, password = auth.partition(':')
+    return user, password

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -69,7 +69,7 @@ def is_using_real_services(request):
 
 @pytest.fixture(scope='session')
 def client():
-    return ScrapinghubClient(auth=TEST_ADMIN_AUTH,
+    return ScrapinghubClient(apikey=TEST_ADMIN_AUTH,
                              endpoint=TEST_HS_ENDPOINT,
                              dash_endpoint=TEST_DASH_ENDPOINT)
 
@@ -81,10 +81,15 @@ def project(client):
 
 @my_vcr.use_cassette()
 @pytest.fixture(scope='session')
-def spider(project):
+def spider(project, request):
     # on normal conditions you can't create a new spider this way:
     # it can only be created on project deploy as usual
-    return project.spiders.get(TEST_SPIDER_NAME, create=True)
+    spider = project.spiders.get(TEST_SPIDER_NAME, create=True)
+    if is_using_real_services(request):
+        existing_tags = spider.list_tags()
+        if existing_tags:
+            spider.update_tags(remove=existing_tags)
+    return spider
 
 
 @pytest.fixture(scope='session')

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -69,7 +69,7 @@ def is_using_real_services(request):
 
 @pytest.fixture(scope='session')
 def client():
-    return ScrapinghubClient(apikey=TEST_ADMIN_AUTH,
+    return ScrapinghubClient(auth=TEST_ADMIN_AUTH,
                              endpoint=TEST_HS_ENDPOINT,
                              dash_endpoint=TEST_DASH_ENDPOINT)
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -44,7 +44,7 @@ def test_client_projects_get_project(client):
     # testing with string project id
     p2 = projects.get(TEST_PROJECT_ID)
     assert isinstance(p2, Project)
-    assert p1.id == p2.id
+    assert p1.key == p2.key
 
 
 def test_client_projects_list_projects(client):

--- a/tests/client/test_collections.py
+++ b/tests/client/test_collections.py
@@ -12,6 +12,19 @@ def _mkitem():
                 field3=3, field4={'v4k': 'v4v'})
 
 
+def test_collections_list(project):
+    # create/check test collections
+    project.collections.get_store(TEST_COLLECTION_NAME),
+    project.collections.get_cached_store(TEST_COLLECTION_NAME),
+    project.collections.get_versioned_store(TEST_COLLECTION_NAME),
+    project.collections.get_versioned_cached_store(TEST_COLLECTION_NAME),
+    collections = project.collections.list()
+    assert isinstance(collections, list)
+    assert len(collections) >= 4
+    for coltype in ('s', 'vs', 'cs', 'vcs'):
+        assert {'name': TEST_COLLECTION_NAME, 'type': coltype} in collections
+
+
 def test_simple_count(project, collection):
     test_item = dict(_mkitem())
     test_item['_key'] = 'a'

--- a/tests/client/test_job.py
+++ b/tests/client/test_job.py
@@ -10,7 +10,7 @@ def test_job_base(client, spider):
     job = spider.jobs.schedule()
     assert isinstance(job, Job)
     assert job.projectid == int(TEST_PROJECT_ID)
-    assert job.key.startswith(TEST_PROJECT_ID + '/' + str(spider.id))
+    assert job.key.startswith(TEST_PROJECT_ID + '/' + str(spider.key))
 
     assert isinstance(job.items, Items)
     assert isinstance(job.logs, Logs)

--- a/tests/client/test_job.py
+++ b/tests/client/test_job.py
@@ -9,8 +9,8 @@ from .conftest import TEST_SPIDER_NAME
 def test_job_base(client, spider):
     job = spider.jobs.schedule()
     assert isinstance(job, Job)
-    assert job.projectid == int(TEST_PROJECT_ID)
-    assert job.key.startswith(TEST_PROJECT_ID + '/' + str(spider.key))
+    assert job.projectid == TEST_PROJECT_ID
+    assert job.key.startswith(spider.key)
 
     assert isinstance(job.items, Items)
     assert isinstance(job.logs, Logs)
@@ -72,8 +72,7 @@ def test_job_start_extras(spider):
         'false': False,
         'nil': None,
     }
-    started = next(job.start(**extras))
-    assert job.key == started['key']
+    assert job.start(**extras) == 'pending'
     for k, v in extras.items():
         if type(v) is float:
             assert abs(job.metadata.get(k) - v) < 0.0001

--- a/tests/client/test_job.py
+++ b/tests/client/test_job.py
@@ -29,9 +29,10 @@ def test_job_update_metadata(spider):
 
 
 def test_job_update_tags(spider):
-    job1 = spider.jobs.schedule(subid='tags-1', add_tag=['tag1'])
-    job2 = spider.jobs.schedule(subid='tags-2', add_tag=['tag2'])
-
+    job1 = spider.jobs.schedule(spider_args={'subid': 'tags-1'},
+                                add_tag=['tag1'])
+    job2 = spider.jobs.schedule(spider_args={'subid': 'tags-2'},
+                                add_tag=['tag2'])
     # FIXME the endpoint normalises tags so it's impossible to send tags
     # having upper-cased symbols, let's add more tests when it's fixed
     assert job1.update_tags(add=['tag11', 'tag12']) == 1

--- a/tests/client/test_project.py
+++ b/tests/client/test_project.py
@@ -14,7 +14,7 @@ from .utils import validate_default_meta
 
 
 def test_project_subresources(project):
-    assert project.id == int(TEST_PROJECT_ID)
+    assert project.key == int(TEST_PROJECT_ID)
     assert isinstance(project.collections, Collections)
     assert isinstance(project.jobs, Jobs)
     assert isinstance(project.spiders, Spiders)

--- a/tests/client/test_project.py
+++ b/tests/client/test_project.py
@@ -14,7 +14,7 @@ from .utils import validate_default_meta
 
 
 def test_project_subresources(project):
-    assert project.key == int(TEST_PROJECT_ID)
+    assert project.key == TEST_PROJECT_ID
     assert isinstance(project.collections, Collections)
     assert isinstance(project.jobs, Jobs)
     assert isinstance(project.spiders, Spiders)
@@ -25,7 +25,7 @@ def test_project_subresources(project):
 
 def test_project_jobs(project):
     jobs = project.jobs
-    assert jobs.projectid == int(TEST_PROJECT_ID)
+    assert jobs.projectid == TEST_PROJECT_ID
     assert jobs.spider is None
 
 
@@ -80,6 +80,30 @@ def test_project_jobs_iter(project):
 
     with pytest.raises(StopIteration):
         next(jobs1)
+
+
+def test_project_jobs_list(project):
+    project.jobs.schedule(TEST_SPIDER_NAME, meta={'state': 'running'})
+
+    # no finished jobs
+    jobs0 = project.jobs.list()
+    assert isinstance(jobs0, list)
+    assert len(jobs0) == 0
+
+    # filter by state must work like for iter
+    jobs1 = project.jobs.list(state='running')
+    assert len(jobs1) == 1
+    job = jobs1[0]
+    assert isinstance(job, dict)
+    ts = job.get('ts')
+    assert isinstance(ts, int) and ts > 0
+    running_time = job.get('running_time')
+    assert isinstance(running_time, int) and running_time > 0
+    elapsed = job.get('elapsed')
+    assert isinstance(elapsed, int) and elapsed > 0
+    assert job.get('key').startswith(TEST_PROJECT_ID)
+    assert job.get('spider') == TEST_SPIDER_NAME
+    assert job.get('state') == 'running'
 
 
 def test_project_jobs_schedule(project):

--- a/tests/client/test_project.py
+++ b/tests/client/test_project.py
@@ -38,13 +38,13 @@ def test_project_jobs_count(project):
 
     for i in range(2):
         project.jobs.schedule(TEST_SPIDER_NAME,
-                              subid='running-%s' % i,
+                              spider_args={'subid': 'running-%s' % i},
                               meta={'state': 'running'})
     assert project.jobs.count(state='running') == 2
 
     for i in range(3):
         project.jobs.schedule(TEST_SPIDER_NAME,
-                              subid='finished%s' % i,
+                              spider_args={'subid': 'finished%s' % i},
                               meta={'state': 'finished'})
     assert project.jobs.count(state='finished') == 3
 
@@ -123,7 +123,7 @@ def test_project_jobs_schedule(project):
         project.jobs.schedule(TEST_SPIDER_NAME)
 
     job1 = project.jobs.schedule(TEST_SPIDER_NAME,
-                                 arg1='val1', arg2='val2',
+                                 spider_args={'arg1':'val1', 'arg2': 'val2'},
                                  priority=3, units=3,
                                  add_tag=['tagA', 'tagB'],
                                  meta={'state': 'running', 'meta1': 'val1'})
@@ -157,7 +157,7 @@ def test_project_jobs_summary(project):
     for state in sorted(counts):
         for i in range(counts[state]):
             job = project.jobs.schedule(TEST_SPIDER_NAME,
-                                        subid=state + str(i),
+                                        spider_args={'subid': state + str(i)},
                                         meta={'state': state})
             jobs[state].append(job.key)
     summary1 = project.jobs.summary()
@@ -202,7 +202,7 @@ def test_project_jobs_iter_last(project):
 
     # next iter_last should return last spider's job
     job2 = project.jobs.schedule(TEST_SPIDER_NAME,
-                                 subid=1,
+                                 spider_args={'subid': 1},
                                  meta={'state': 'finished'})
     lastsumm2 = list(project.jobs.iter_last())
     assert len(lastsumm2) == 1

--- a/tests/client/test_spider.py
+++ b/tests/client/test_spider.py
@@ -16,7 +16,7 @@ from .utils import validate_default_meta
 def test_spiders_get(project):
     spider = project.spiders.get(TEST_SPIDER_NAME)
     assert isinstance(spider, Spider)
-    assert isinstance(spider.id, int)
+    assert isinstance(spider.key, int)
     assert spider.name == TEST_SPIDER_NAME
     assert spider.projectid == int(TEST_PROJECT_ID)
     assert isinstance(spider.jobs, Jobs)
@@ -32,7 +32,7 @@ def test_spiders_list(project):
 
 
 def test_spider_base(project, spider):
-    assert spider.id == 1
+    assert spider.key == 1
     assert spider.name == TEST_SPIDER_NAME
     assert spider.projectid == int(TEST_PROJECT_ID)
     assert isinstance(project.jobs, Jobs)
@@ -152,7 +152,7 @@ def test_spider_jobs_get(spider):
     with pytest.raises(ValueError):
         spider.jobs.get(TEST_PROJECT_ID + '/2/3')
 
-    fake_job_id = str(JobKey(TEST_PROJECT_ID, spider.id, 3))
+    fake_job_id = str(JobKey(TEST_PROJECT_ID, spider.key, 3))
     fake_job = spider.jobs.get(fake_job_id)
     assert isinstance(fake_job, Job)
 

--- a/tests/client/test_spider.py
+++ b/tests/client/test_spider.py
@@ -66,11 +66,13 @@ def test_spider_jobs_count(spider):
     assert jobs.count(state='pending') == 1
 
     for i in range(2):
-        jobs.schedule(subid='running-%s' % i, meta={'state': 'running'})
+        jobs.schedule(spider_args={'subid': 'running-%s' % i},
+                      meta={'state': 'running'})
     assert jobs.count(state='running') == 2
 
     for i in range(3):
-        jobs.schedule(subid='finished%s' % i, meta={'state': 'finished'})
+        jobs.schedule(spider_args={'subid': 'finished%s' % i},
+                      meta={'state': 'finished'})
     assert jobs.count(state='finished') == 3
 
     assert jobs.count(state=['pending', 'running', 'finished']) == 6
@@ -141,7 +143,7 @@ def test_spider_jobs_schedule(spider):
     with pytest.raises(DuplicateJobError):
         spider.jobs.schedule()
 
-    job1 = spider.jobs.schedule(arg1='val1', arg2='val2',
+    job1 = spider.jobs.schedule(spider_args={'arg1': 'val1', 'arg2': 'val2'},
                                 priority=3, units=3,
                                 meta={'state': 'running', 'meta1': 'val1'},
                                 add_tag=['tagA', 'tagB'])
@@ -184,7 +186,7 @@ def test_spider_jobs_summary(spider):
     jobs = defaultdict(list)
     for state in sorted(counts):
         for i in range(counts[state]):
-            job = spider.jobs.schedule(subid=state + str(i),
+            job = spider.jobs.schedule(spider_args={'subid': state + str(i)},
                                        meta={'state': state})
             jobs[state].append(job.key)
     summary1 = spider.jobs.summary()
@@ -228,7 +230,8 @@ def test_spider_jobs_iter_last(spider):
     assert lastsumm1[0].get('ts') > 0
 
     # next iter_last should return last spider's job again
-    job2 = spider.jobs.schedule(subid=1, meta={'state': 'finished'})
+    job2 = spider.jobs.schedule(spider_args={'subid': 1},
+                                meta={'state': 'finished'})
     lastsumm2 = list(spider.jobs.iter_last())
     assert len(lastsumm2) == 1
     assert lastsumm2[0].get('key') == job2.key

--- a/tests/client/test_spider.py
+++ b/tests/client/test_spider.py
@@ -30,9 +30,9 @@ def test_spiders_list(project):
 
 
 def test_spider_base(project, spider):
-    assert isinstance(spider.id, string_types)
+    assert isinstance(spider._id, string_types)
     assert isinstance(spider.key, string_types)
-    assert spider.key == spider.projectid + '/' + spider.id
+    assert spider.key == spider.projectid + '/' + spider._id
     assert spider.name == TEST_SPIDER_NAME
     assert spider.projectid == TEST_PROJECT_ID
     assert isinstance(project.jobs, Jobs)
@@ -169,7 +169,7 @@ def test_spider_jobs_get(spider):
     with pytest.raises(ValueError):
         spider.jobs.get(TEST_PROJECT_ID + '/2/3')
 
-    fake_job_id = str(JobKey(spider.projectid, spider.id, 3))
+    fake_job_id = str(JobKey(spider.projectid, spider._id, 3))
     fake_job = spider.jobs.get(fake_job_id)
     assert isinstance(fake_job, Job)
 

--- a/tests/client/test_utils.py
+++ b/tests/client/test_utils.py
@@ -1,0 +1,37 @@
+import pytest
+from scrapinghub.utils import format_iter_filters
+
+
+def test_format_iter_filters():
+    # work with empty params
+    assert format_iter_filters({}) == {}
+
+    # doesn't affect other params
+    params = {'a': 123, 'b': 456}
+    assert format_iter_filters(params) == params
+
+    # pass filter as-is if not list
+    params = {'filter': 'some-string'}
+    assert format_iter_filters(params) == params
+
+    # work fine with empty filter
+    params = {'filter': []}
+    assert format_iter_filters(params) == params
+
+    # pass string filters as-is
+    params = {'filter': ['str1', 'str2']}
+    assert format_iter_filters(params) == params
+
+    # converts list-formatted filters
+    params = {'filter': [['field', '>=', ['val']], 'filter2']}
+    assert (format_iter_filters(params) ==
+            {'filter': ['["field", ">=", ["val"]]', 'filter2']})
+
+    # works the same with tuple entries
+    params = {'filter': [('field', '==', ['val'])]}
+    assert (format_iter_filters(params) ==
+            {'filter': ['["field", "==", ["val"]]']})
+
+    # exception if entry is not list/tuple or string
+    with pytest.raises(ValueError):
+        format_iter_filters({'filter': ['test', 123]})

--- a/tests/client/test_utils.py
+++ b/tests/client/test_utils.py
@@ -76,6 +76,11 @@ def test_parse_auth_simple():
     assert parse_auth('user:pass') == ('user', 'pass')
 
 
+def test_parse_auth_bad_apikey():
+    with pytest.raises(ValueError):
+        parse_auth('apikey')
+
+
 def test_parse_auth_apikey():
     test_key = u'\xe3\x98\xb8\xe6\x91\x84\xe9'
     apikey = encode(test_key.encode('utf8'), 'hex_codec').decode('ascii')

--- a/tests/client/test_utils.py
+++ b/tests/client/test_utils.py
@@ -55,7 +55,7 @@ def test_parse_auth_none_with_env():
 
 def test_parse_auth_tuple():
     assert parse_auth(('test', 'test')) == ('test', 'test')
-    assert parse_auth(('apikey', None)) == ('apikey', None)
+    assert parse_auth(('apikey', '')) == ('apikey', '')
 
     with pytest.raises(ValueError):
         parse_auth(('user', 'pass', 'bad-param'))
@@ -76,14 +76,8 @@ def test_parse_auth_simple():
     assert parse_auth('user:pass') == ('user', 'pass')
 
 
-def test_parse_auth_bad_apikey():
-    with pytest.raises(ValueError):
-        parse_auth('apikey')
-
-
 def test_parse_auth_apikey():
-    test_key = u'\xe3\x98\xb8\xe6\x91\x84\xe9'
-    apikey = encode(test_key.encode('utf8'), 'hex_codec').decode('ascii')
+    apikey = 'c3a3c298c2b8c3a6c291c284c3a9'
     assert parse_auth(apikey) == (apikey, '')
 
 

--- a/tests/legacy/test_connection.py
+++ b/tests/legacy/test_connection.py
@@ -32,11 +32,6 @@ def test_connection_init_assert_apikey_not_url():
         Connection(password='testpass', apikey='http://some-url')
 
 
-def test_connection_init_with_password():
-    with pytest.raises(AssertionError):
-        Connection(apikey='testkey', password='testpass')
-
-
 def test_connection_init_with_default_url():
     conn = Connection(apikey='testkey')
     assert conn.url == Connection.DEFAULT_ENDPOINT


### PR DESCRIPTION
The PR is created to cover the following minor things found after testing:
- [x] fix inconsistencies between `project.id - spider.id - job.key` (use `key` or `id` everywhere)
- [x] collection.set() should return None instead of a generator
- [x] simplify and unify using HS `filter` param 
- [x] activity.add(): add client validation for project id
- [x] collections.iter() should iterate through collections
- [x] unify errors when apikey is wrong (now it's `InvalidUsage` or `ScrapinghubAPIError`)
- [x] handle HTTP 401 from JobQ separately with providing a good message instead of html

Other issues added after next step of testing at February 8th:
- [x] collection.delete() should return None instead of a generator
- [x] add validation for collection.delete input
- [x] validate that update_tags method has any input

Also there's a new `spider.update_tags` method that will be added on server-side soon.

Each of the points will be implemented in a separate commit(s) to simplify reviewing.