### PR TITLE
Explicitly show how to install pre-release (until 2.0 is out)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,12 +23,12 @@ Installation
 
 The quick way::
 
-    pip install scrapinghub
+    pip install --pre scrapinghub
 
 You can also install the library with MessagePack support, it provides better
 response time and improved bandwidth usage::
 
-    pip install scrapinghub[msgpack]
+    pip install --pre scrapinghub[msgpack]
 
 
 New client


### PR DESCRIPTION
This is temporary, until https://github.com/scrapinghub/python-scrapinghub/pull/57 gets merged, 
so that current README and examples (the only doc for now) work correctly.