### PR TITLE
Fix API docs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,5 +33,5 @@ Documentation
 Documentation is `available online`_ via Read the Docs or in the ``docs`` directory.
 
 
-.. _Scrapinghub API: http://doc.scrapinghub.com/api.html
+.. _Scrapinghub API: https://doc.scrapinghub.com/scrapy-cloud.html#scrapycloud
 .. _available online: https://python-scrapinghub.readthedocs.io/

--- a/docs/client/overview.rst
+++ b/docs/client/overview.rst
@@ -596,7 +596,7 @@ Exceptions
 .. autoexception:: scrapinghub.ServerError
 
 
-.. _Scrapinghub API: http://doc.scrapinghub.com/api.html
-.. _Frontier: http://doc.scrapinghub.com/api/frontier.html
+.. _Scrapinghub API: https://doc.scrapinghub.com/scrapy-cloud.html#scrapycloud
+.. _Frontier: https://doc.scrapinghub.com/api/frontier.html
 .. _count endpoint: https://doc.scrapinghub.com/api/jobq.html#jobq-project-id-count
 .. _list endpoint: https://doc.scrapinghub.com/api/jobq.html#jobq-project-id-list

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Client interface for Scrapinghub API
 
 The ``scrapinghub`` is a Python library for communicating with the `Scrapinghub API`_.
 
-.. _Scrapinghub API: http://doc.scrapinghub.com/api.html
+.. _Scrapinghub API: https://doc.scrapinghub.com/scrapy-cloud.html#scrapycloud
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
https://doc.scrapinghub.com/api.html yields a 404