### PR TITLE
Parent param is optional for requests.add

### DIFF
--- a/scrapinghub/client/requests.py
+++ b/scrapinghub/client/requests.py
@@ -41,16 +41,16 @@ class Requests(_ItemsResourceProxy, _DownloadableProxyMixin):
             'url': 'https://example.com'
         }]
     """
-    def add(self, url, status, method, rs, parent, duration, ts, fp=None):
+    def add(self, url, status, method, rs, duration, ts, parent=None, fp=None):
         """ Add a new requests.
 
         :param url: string url for the request.
         :param status: HTTP status of the request.
         :param method: stringified request method.
         :param rs: response body length.
-        :param parent: parent request id or ``None``.
         :param duration: request duration in milliseconds.
         :param ts: UNIX timestamp in milliseconds.
+        :param parent: (optional) parent request id.
         :param fp: (optional) string fingerprint for the request.
         """
         return self._origin.add(

--- a/tests/client/test_requests.py
+++ b/tests/client/test_requests.py
@@ -6,7 +6,7 @@ from .conftest import TEST_TS
 def _add_test_requests(job):
     r1 = job.requests.add(
         url='http://test.com/', status=200, method='GET',
-        rs=1337, duration=5, parent=None, ts=TEST_TS)
+        rs=1337, duration=5, ts=TEST_TS)
     job.requests.add(
         url='http://test.com/2', status=400, method='POST',
         rs=0, duration=1, parent=r1, ts=TEST_TS + 1)


### PR DESCRIPTION
Small fix to make `parent` param optional.

Addressing https://github.com/scrapinghub/doc.scrapinghub.com/pull/162#pullrequestreview-29726747.