### PR TITLE
Fix messagepack-based tests

### DIFF
--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -126,6 +126,15 @@ def setup_session(client, project, collection, request):
     client.close()
 
 
+@pytest.fixture(params=['json', 'msgpack'])
+def json_and_msgpack(client, monkeypatch, request):
+    if request.param == 'json':
+        monkeypatch.setattr(client._hsclient, 'use_msgpack', False)
+    elif not MSGPACK_AVAILABLE or request.config.getoption("--disable-msgpack"):
+        pytest.skip("messagepack-based tests are disabled")
+    return request.param
+
+
 @pytest.fixture(autouse=True)
 def setup_vcrpy(request, project):
     # generates names like "test_module/test_function{-json}.yaml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,16 +16,6 @@ def pytest_addoption(parser):
         help="disable messagepack-serialization based tests")
 
 
-@pytest.fixture(params=['json', 'msgpack'])
-def json_and_msgpack(pytestconfig, monkeypatch, request):
-    if request.param == 'json':
-        monkeypatch.setattr('scrapinghub.hubstorage.resourcetype.MSGPACK_AVAILABLE', False)
-        monkeypatch.setattr('scrapinghub.hubstorage.collectionsrt.MSGPACK_AVAILABLE', False)
-    elif not MSGPACK_AVAILABLE or request.config.getoption("--disable-msgpack"):
-        pytest.skip("messagepack-based tests are disabled")
-    return request.param
-
-
 def request_accept_header_matcher(r1, r2):
     """Custom VCR.py matcher by Accept header."""
 

--- a/tests/hubstorage/conftest.py
+++ b/tests/hubstorage/conftest.py
@@ -11,6 +11,7 @@ from requests import HTTPError
 
 from scrapinghub import HubstorageClient
 from scrapinghub.hubstorage.utils import urlpathjoin
+from scrapinghub.hubstorage.serialization import MSGPACK_AVAILABLE
 
 from ..conftest import request_accept_header_matcher
 
@@ -103,6 +104,15 @@ def setup_session(hsclient, hsproject, hscollection, request):
         remove_all_jobs(hsproject)
     yield
     hsclient.close()
+
+
+@pytest.fixture(params=['json', 'msgpack'])
+def json_and_msgpack(hsclient, monkeypatch, request):
+    if request.param == 'json':
+        monkeypatch.setattr(hsclient, 'use_msgpack', False)
+    elif not MSGPACK_AVAILABLE or request.config.getoption("--disable-msgpack"):
+        pytest.skip("messagepack-based tests are disabled")
+    return request.param
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hubstorage/test_collections.py
+++ b/tests/hubstorage/test_collections.py
@@ -134,7 +134,6 @@ def test_invalid_collection_name(hsproject):
             method(*args)
 
 
-@pytest.mark.parametrize('msgpack_available', [True, False])
 @pytest.mark.parametrize('path,expected_result', [
         ('s/foo', True),
         ('s/foo/', True),
@@ -154,7 +153,6 @@ def test_invalid_collection_name(hsproject):
         ('list', False),
         (None, False),
 ])
-def test_allows_msgpack(msgpack_available, path, expected_result):
-    hsclient = HubstorageClient(use_msgpack=msgpack_available)
+def test_allows_msgpack(hsclient, path, expected_result, json_and_msgpack):
     collections = hsclient.get_project(2222000).collections
-    assert collections._allows_mpack(path) is (msgpack_available and expected_result)
+    assert collections._allows_mpack(path) is (hsclient.use_msgpack and expected_result)

--- a/tests/hubstorage/test_project.py
+++ b/tests/hubstorage/test_project.py
@@ -88,7 +88,8 @@ def test_push_job(hsproject):
 
 def test_auth(hsclient, json_and_msgpack):
     # client without global auth set
-    hsc = HubstorageClient(endpoint=hsclient.endpoint)
+    hsc = HubstorageClient(endpoint=hsclient.endpoint,
+                           use_msgpack=hsclient.use_msgpack)
     assert hsc.auth is None
 
     # check no-auth access
@@ -279,7 +280,6 @@ def test_output_string(hsclient, hsproject):
     assert isinstance(next(items), str)
 
 
-@pytest.mark.parametrize('msgpack_available', [True, False])
 @pytest.mark.parametrize('path,expected_result', [
     (None, True),
     ('33/1', True),
@@ -291,11 +291,10 @@ def test_output_string(hsclient, hsproject):
     ('33/1/stats/', False),
     ((33, 1, 'stats'), False),
 ])
-def test_allows_msgpack(msgpack_available, path, expected_result):
-    hsclient = HubstorageClient(use_msgpack=msgpack_available)
+def test_allows_msgpack(hsclient, path, expected_result, json_and_msgpack):
     job = hsclient.get_job('2222000/1/1')
     for resource in [job.items, job.logs, job.samples]:
-        assert resource._allows_mpack(path) is (msgpack_available and expected_result)
+        assert resource._allows_mpack(path) is (hsclient.use_msgpack and expected_result)
     assert job.requests._allows_mpack(path) is False
     assert job.metadata._allows_mpack(path) is False
     assert job.jobq._allows_mpack(path) is False


### PR DESCRIPTION
Initial idea with having a single `json_and_msgpack` fixture on project level failed because we changed workflow and now don't check for `MSGPACK_AVAILABLE` all the time, but rely on option in client instance. So the fixtures should be split across the clients and monkeypatch logic should be changed correspondingly depending on fixture parameter value.

Review, please.