### PR TITLE
Update quickstart with correct items call

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -47,7 +47,7 @@ Run a new job for one of your projects::
 Access your job's output data::
 
     >>> job = client.get_job('123/1/2')
-    >>> for item in job.items():
+    >>> for item in job.items.iter():
     ...     print(item)
     {
         'name': ['Some item'],


### PR DESCRIPTION
See #79

Saying `job.items()` results in a callable error, I think the right syntax is the one in the pydoc: `job.items.iter()`

Right❓ 