### PR TITLE
Convert TZ-aware datetime object to POSIX one

### DIFF
--- a/scrapinghub/hubstorage/serialization.py
+++ b/scrapinghub/hubstorage/serialization.py
@@ -40,6 +40,9 @@ def jsonencode(o):
 
 def jsondefault(o):
     if isinstance(o, datetime):
+        # convert TZ-aware datetime object to POSIX timestamp
+        if o.tzinfo:
+            o = o.replace(tzinfo=None) - o.utcoffset()
         delta = o - EPOCH
         u = delta.microseconds
         s = delta.seconds

--- a/tests/hubstorage/test_serialization.py
+++ b/tests/hubstorage/test_serialization.py
@@ -1,0 +1,21 @@
+""" Serialization utils module.  """
+
+from datetime import datetime, timedelta, tzinfo
+
+from scrapinghub.hubstorage.serialization import jsondefault
+
+
+def test_jsondefault_timezones():
+
+    class TestTZ(tzinfo):
+
+        def utcoffset(self, dt):
+            return timedelta(minutes=-399)
+
+    # base tz unaware datetime
+    dt = datetime(2017, 5, 4, 3, 2, 1, 123456)
+    dt_ts = jsondefault(dt)
+    # tz aware datetime with test TZ
+    dt_tz = dt.replace(tzinfo=TestTZ())
+    dt_tz_ts = jsondefault(dt_tz)
+    assert dt_tz_ts == dt_ts + 399 * 60 * 1000


### PR DESCRIPTION
As all the serialization logic is needed to store data to Hubstorage, and we store only POSIX timestamps, the only thing to do is convert datetime to UTC based on a given timezone information.

Addressing https://github.com/scrapinghub/python-scrapinghub/issues/80.