### PR TITLE
Send request data as str/bytes

### DIFF
--- a/scrapinghub/hubstorage/resourcetype.py
+++ b/scrapinghub/hubstorage/resourcetype.py
@@ -54,7 +54,9 @@ class ResourceType(object):
         kwargs['url'] = urlpathjoin(self.url, _path)
         kwargs.setdefault('auth', self.auth)
         if 'jl' in kwargs:
-            kwargs['data'] = jlencode(kwargs.pop('jl'))
+            # XXX explicitly encode data to overcome shazow/urllib3#717
+            # when dealing with large POST requests with enabled TLS
+            kwargs['data'] = jlencode(kwargs.pop('jl')).encode('utf-8')
 
         r = self.client.request(**kwargs)
 


### PR DESCRIPTION
A short fix to overcome https://github.com/shazow/urllib3/issues/717 related to large POST requests via SSL raising `SSL3_WRITE_PENDING` error.