### PR TITLE
Enforce using pytest<3.3.0 to fix Travis builds

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,8 @@
 mock
 vcrpy==1.10.3
-pytest
+# FIXME remove the constraint after resolving
+# https://github.com/pytest-dev/pytest/issues/2966
+pytest<3.3.0
 pytest-cov
 pytest-catchlog
 responses==0.5.0


### PR DESCRIPTION
Latest pytest 3.3.0 [doesn't support](https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst#pytest-330-2017-11-23) python 3.3, it leads to the errors similar to the described in [this issue](https://github.com/pytest-dev/pytest/issues/2966).
The PR enforces `pytest<3.3.0`, hopefully there will be a better way when the pytest issue is resolved.