### PR TITLE
Recover iter logic when using count param

### DIFF
--- a/scrapinghub/client/proxy.py
+++ b/scrapinghub/client/proxy.py
@@ -78,7 +78,7 @@ class _ItemsResourceProxy(_Proxy):
         :return: a generator object over a list of element dictionaries.
         :rtype: :class:`types.GeneratorType[dict]`
         """
-        update_kwargs(params or {}, count=count)
+        update_kwargs(params, count=count)
         params = self._modify_iter_params(params)
         return self._origin.list(_key, **params)
 

--- a/tests/client/test_proxy.py
+++ b/tests/client/test_proxy.py
@@ -1,6 +1,8 @@
+import mock
 import pytest
 
 from scrapinghub.client.proxy import _format_iter_filters
+from scrapinghub.client.proxy import _ItemsResourceProxy
 
 
 def test_format_iter_filters():
@@ -36,3 +38,18 @@ def test_format_iter_filters():
     # exception if entry is not list/tuple or string
     with pytest.raises(ValueError):
         _format_iter_filters({'filter': ['test', 123]})
+
+
+def test_item_resource_iter_no_params():
+    items_proxy = _ItemsResourceProxy(mock.Mock, mock.Mock(), 'mocked_key')
+    items_proxy._origin = mock.Mock()
+    items_proxy.iter(count=123)
+    assert items_proxy._origin.list.call_args == mock.call(None, count=123)
+
+
+def test_item_resource_iter_with_params():
+    items_proxy = _ItemsResourceProxy(mock.Mock, mock.Mock(), 'mocked_key')
+    items_proxy._origin = mock.Mock()
+    items_proxy.iter(count=123, startts=12345)
+    assert (items_proxy._origin.list.call_args ==
+            mock.call(None, count=123, startts=12345))


### PR DESCRIPTION
Ther was a tiny hidden bug "swallowing" `count` parameter when using it w/o other filters. 

Addressing #76 and #89.