### PR TITLE
Provide unified connection timeout

### DIFF
--- a/scrapinghub/client/__init__.py
+++ b/scrapinghub/client/__init__.py
@@ -49,13 +49,13 @@ class ScrapinghubClient(object):
                  connection_timeout=DEFAULT_CONNECTION_TIMEOUT, **kwargs):
         self.projects = Projects(self)
         login, password = parse_auth(auth)
+        timeout = connection_timeout or DEFAULT_CONNECTION_TIMEOUT
         self._connection = Connection(apikey=login,
                                       password=password,
                                       url=dash_endpoint,
-                                      connection_timeout=connection_timeout)
+                                      connection_timeout=timeout)
         self._hsclient = HubstorageClient(auth=(login, password),
-                                          connection_timeout=connection_timeout,
-                                          **kwargs)
+                                          connection_timeout=timeout, **kwargs)
 
     def get_project(self, project_id):
         """Get :class:`scrapinghub.client.projects.Project` instance with

--- a/scrapinghub/client/__init__.py
+++ b/scrapinghub/client/__init__.py
@@ -9,6 +9,8 @@ from .utils import parse_project_id, parse_job_key
 
 __all__ = ['ScrapinghubClient']
 
+DEFAULT_CONNECTION_TIMEOUT = 60
+
 
 class Connection(_Connection):
 
@@ -43,13 +45,17 @@ class ScrapinghubClient(object):
         <scrapinghub.client.ScrapinghubClient at 0x1047af2e8>
     """
 
-    def __init__(self, auth=None, dash_endpoint=None, **kwargs):
+    def __init__(self, auth=None, dash_endpoint=None,
+                 connection_timeout=DEFAULT_CONNECTION_TIMEOUT, **kwargs):
         self.projects = Projects(self)
         login, password = parse_auth(auth)
         self._connection = Connection(apikey=login,
                                       password=password,
-                                      url=dash_endpoint)
-        self._hsclient = HubstorageClient(auth=(login, password), **kwargs)
+                                      url=dash_endpoint,
+                                      connection_timeout=connection_timeout)
+        self._hsclient = HubstorageClient(auth=(login, password),
+                                          connection_timeout=connection_timeout,
+                                          **kwargs)
 
     def get_project(self, project_id):
         """Get :class:`scrapinghub.client.projects.Project` instance with

--- a/scrapinghub/legacy.py
+++ b/scrapinghub/legacy.py
@@ -53,7 +53,8 @@ class Connection(object):
         'reports_add': 'reports/add',
     }
 
-    def __init__(self, apikey=None, password='', _old_passwd='', url=None):
+    def __init__(self, apikey=None, password='', _old_passwd='',
+                 url=None, connection_timeout=None):
         if apikey is None:
             apikey = os.environ.get('SH_APIKEY')
             if apikey is None:
@@ -67,6 +68,7 @@ class Connection(object):
         self.password = password or ''
         self.url = url or self.DEFAULT_ENDPOINT
         self._session = self._create_session()
+        self._connection_timeout = connection_timeout
 
     def __repr__(self):
         return "Connection(%r)" % self.apikey
@@ -132,10 +134,12 @@ class Connection(object):
                            _type=APIError.ERR_VALUE_ERROR)
 
         if data is None and files is None:
-            response = self._session.get(url, headers=headers)
+            response = self._session.get(url, headers=headers,
+                                         timeout=self._connection_timeout)
         else:
             response = self._session.post(url, headers=headers,
-                                          data=data, files=files)
+                                          data=data, files=files,
+                                          timeout=self._connection_timeout)
         return self._decode_response(response, format, raw)
 
     def _decode_response(self, response, format, raw):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -2,6 +2,7 @@ from scrapinghub import Connection
 from scrapinghub import HubstorageClient
 from scrapinghub import ScrapinghubClient
 
+from scrapinghub.client import DEFAULT_CONNECTION_TIMEOUT
 from scrapinghub.client.jobs import Job
 from scrapinghub.client.projects import Projects, Project
 
@@ -18,6 +19,7 @@ def test_client_base(client):
     assert isinstance(client._hsclient, HubstorageClient)
     assert client._connection
     assert isinstance(client._connection, Connection)
+    assert client._connection._connection_timeout == DEFAULT_CONNECTION_TIMEOUT
     assert client.projects
     assert isinstance(client.projects, Projects)
 


### PR DESCRIPTION
Addressing #19.

`HubstorageClient` already relies on `connection_timeout` param, I believe we want to keep its current behaviour and reuse it for `Connection` (with default to `None`, again - to keep the current logic).