### PR TITLE
Python 3.3 is considered unmaintained

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ matrix:
       env: TOXENV=pypy-json
     - python: pypy
       env: TOXENV=pypy-msgpack
-    - python: 3.3
-      env: TOXENV=py33-json
-    - python: 3.3
-      env: TOXENV=py33-msgpack
     - python: 3.4
       env: TOXENV=py34-json
     - python: 3.4

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,py,33,34,35,36}-{json,msgpack}
+envlist = py{27,py,34,35,36}-{json,msgpack}
 
 [testenv]
 deps =


### PR DESCRIPTION
Any objections? I wonder if it's worth to try to recover the tests suite for Python 3.3.

Follow-up from https://github.com/scrapinghub/python-scrapinghub/pull/98#issuecomment-395006457.

![screenshot_2018-06-12_14-16-54](https://user-images.githubusercontent.com/448111/41287430-5a660104-6e4b-11e8-8892-0e30f4ca51da.png)
