### PR TITLE
Pin pytest-cov version to fix Travis build

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,6 @@ vcrpy==1.10.3
 # FIXME remove the constraint after resolving
 # https://github.com/pytest-dev/pytest/issues/2966
 pytest<3.3.0
-pytest-cov
+pytest-cov<2.6.0
 pytest-catchlog
 responses==0.5.0


### PR DESCRIPTION
The best description of the problem is given by https://github.com/pywbem/pywbem/issues/1371#issuecomment-418785850:

> Analysis shows that this is related to the issue around requiring different versions of the coverage package: pytest-cov 2.6.0 has increased the version requirement for the coverage package from >=3.7.1 to >=4.4, which is in conflict with the version requirement defined by the python-coveralls package for coverage==4.0.3. Issue z4r/python-coveralls#66 has been opened. Workaround is to pin the pytest_cov version to below 2.6.0.