### PR TITLE
Add long_description to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
+[metadata]
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
https://pypi.org/project/scrapinghub/ doesn't contain any description

The result of running twine check after the changes:
```
(python-scrapinghub) bash-3.2$ twine check dist/*
Checking distribution dist/scrapinghub-2.1.0-py2.py3-none-any.whl: Passed
Checking distribution dist/scrapinghub-2.1.0.tar.gz: Passed
```