### PR TITLE
Refactoring VcrGzipSerializer to normalize new cassettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist
 
 # documentation
 docs/_build
+
+.DS_Store
+pytestdebug.log

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -1,7 +1,4 @@
 import os
-import zlib
-import base64
-import pickle
 
 import vcr
 import pytest
@@ -12,41 +9,22 @@ from scrapinghub.client.exceptions import NotFound
 from scrapinghub.hubstorage.serialization import MSGPACK_AVAILABLE
 
 from ..conftest import request_accept_header_matcher
-
-
-TEST_PROJECT_ID = "2222222"
-TEST_SPIDER_NAME = 'hs-test-spider'
-TEST_FRONTIER_SLOT = 'site.com'
-TEST_BOTGROUP = 'python-hubstorage-test'
-TEST_COLLECTION_NAME = "test_collection_123"
-TEST_ADMIN_AUTH = os.getenv('AUTH', 'f' * 32)
-TEST_USER_AUTH = os.getenv('USER_AUTH', 'e' * 32)
-TEST_DASH_ENDPOINT = os.getenv('DASH_ENDPOINT', 'http://33.33.33.51:8080/api/')
-TEST_HS_ENDPOINT = os.getenv('HS_ENDPOINT',
-                             'http://storage.vm.scrapinghub.com')
+from ..conftest import VCRGzipSerializer
+from ..conftest import (
+    TEST_SPIDER_NAME,
+    TEST_FRONTIER_SLOT,
+    TEST_COLLECTION_NAME,
+    TEST_ENDPOINT,
+    TEST_PROJECT_ID,
+    TEST_ADMIN_AUTH,
+    TEST_DASH_ENDPOINT,
+)
 
 # use some fixed timestamp to represent current time
 TEST_TS = 1476803148638
 
 # vcrpy creates the cassetes automatically under VCR_CASSETES_DIR
 VCR_CASSETES_DIR = 'tests/client/cassetes'
-
-
-class VCRGzipSerializer(object):
-    """Custom ZIP serializer for VCR.py."""
-
-    def serialize(self, cassette_dict):
-        # receives a dict, must return a string
-        # there can be binary data inside some of the requests,
-        # so it's impossible to use json for serialization to string
-        compressed = zlib.compress(pickle.dumps(cassette_dict, protocol=2))
-        return base64.b64encode(compressed).decode('utf8')
-
-    def deserialize(self, cassette_string):
-        # receives a string, must return a dict
-        decoded = base64.b64decode(cassette_string.encode('utf8'))
-        return pickle.loads(zlib.decompress(decoded))
-
 
 my_vcr = vcr.VCR(cassette_library_dir=VCR_CASSETES_DIR, record_mode='once')
 my_vcr.register_serializer('gz', VCRGzipSerializer())
@@ -79,7 +57,7 @@ def is_using_real_services(request):
 @pytest.fixture(scope='session')
 def client():
     return ScrapinghubClient(auth=TEST_ADMIN_AUTH,
-                             endpoint=TEST_HS_ENDPOINT,
+                             endpoint=TEST_ENDPOINT,
                              dash_endpoint=TEST_DASH_ENDPOINT)
 
 

--- a/tests/client/test_activity.py
+++ b/tests/client/test_activity.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from .conftest import TEST_PROJECT_ID
+from ..conftest import TEST_PROJECT_ID
 
 
 def _add_test_activity(project):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -6,7 +6,7 @@ from scrapinghub.client import DEFAULT_CONNECTION_TIMEOUT
 from scrapinghub.client.jobs import Job
 from scrapinghub.client.projects import Projects, Project
 
-from .conftest import TEST_PROJECT_ID
+from ..conftest import TEST_PROJECT_ID
 
 
 # ScrapinghubClient class tests

--- a/tests/client/test_collections.py
+++ b/tests/client/test_collections.py
@@ -7,7 +7,7 @@ from scrapinghub.client.exceptions import BadRequest
 from scrapinghub.client.exceptions import NotFound
 from scrapinghub.client.exceptions import ValueTooLarge
 
-from .conftest import TEST_COLLECTION_NAME
+from ..conftest import TEST_COLLECTION_NAME
 
 
 def _mkitem():

--- a/tests/client/test_frontiers.py
+++ b/tests/client/test_frontiers.py
@@ -5,7 +5,7 @@ from collections import Iterable
 from six import string_types
 
 from scrapinghub.client.frontiers import Frontiers, Frontier, FrontierSlot
-from .conftest import TEST_FRONTIER_SLOT
+from ..conftest import TEST_FRONTIER_SLOT
 
 
 def _add_test_requests_to_frontier(frontier):

--- a/tests/client/test_job.py
+++ b/tests/client/test_job.py
@@ -9,8 +9,8 @@ from scrapinghub.client.logs import Logs
 from scrapinghub.client.requests import Requests
 from scrapinghub.client.samples import Samples
 
-from .conftest import TEST_PROJECT_ID
-from .conftest import TEST_SPIDER_NAME
+from ..conftest import TEST_PROJECT_ID
+from ..conftest import TEST_SPIDER_NAME
 
 
 def test_job_base(client, spider):

--- a/tests/client/test_projects.py
+++ b/tests/client/test_projects.py
@@ -17,8 +17,8 @@ from scrapinghub.client.spiders import Spiders
 
 from scrapinghub.hubstorage.utils import apipoll
 
-from .conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
-from .conftest import TEST_USER_AUTH, TEST_DASH_ENDPOINT
+from ..conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
+from ..conftest import TEST_USER_AUTH, TEST_DASH_ENDPOINT
 from .utils import validate_default_meta
 
 

--- a/tests/client/test_spiders.py
+++ b/tests/client/test_spiders.py
@@ -12,7 +12,7 @@ from scrapinghub.client.jobs import Jobs, Job
 from scrapinghub.client.spiders import Spider
 from scrapinghub.client.utils import JobKey
 
-from .conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
+from ..conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
 from .utils import validate_default_meta
 
 

--- a/tests/client/utils.py
+++ b/tests/client/utils.py
@@ -1,5 +1,5 @@
-from .conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
-from .conftest import TEST_DASH_ENDPOINT
+from ..conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
+from ..conftest import TEST_DASH_ENDPOINT
 
 
 def validate_default_meta(meta, state='pending', units=1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,16 +47,7 @@ class VCRGzipSerializer(object):
 
 
 def normalize_endpoint(uri, endpoint, default_endpoint):
-    old = endpoint
-    new = default_endpoint
-
-    if old.endswith('/'):
-        old = old[:-1]
-
-    if new.endswith('/'):
-        new = new[:-1]
-
-    return uri.replace(old, new)
+    return uri.replace(endpoint.rstrip('/'), default_endpoint.rstrip('/'))
 
 
 def normalize_cassette(cassette_dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,99 @@
 # -*- coding: utf-8 -*-
+import base64
+import os
+import pickle
 import pytest
 import re
+import zlib
 
 from scrapinghub.hubstorage.serialization import MSGPACK_AVAILABLE
+from scrapinghub import HubstorageClient
+from scrapinghub.legacy import Connection
+
+
+DEFAULT_PROJECT_ID = "2222222"
+DEFAULT_ENDPOINT = 'http://storage.vm.scrapinghub.com'
+DEFAULT_DASH_ENDPOINT = 'http://33.33.33.51:8080/api/'
+
+
+TEST_PROJECT_ID = os.getenv('HS_PROJECT_ID', DEFAULT_PROJECT_ID)
+TEST_SPIDER_NAME = 'hs-test-spider'
+TEST_FRONTIER_SLOT = 'site.com'
+TEST_BOTGROUP = 'python-hubstorage-test'
+TEST_COLLECTION_NAME = "test_collection_123"
+TEST_AUTH = os.getenv('HS_AUTH', 'f' * 32)
+TEST_ENDPOINT = os.getenv('HS_ENDPOINT', DEFAULT_ENDPOINT)
+TEST_COLLECTION_NAME = "test_collection_123"
+TEST_ADMIN_AUTH = os.getenv('AUTH', 'f' * 32)
+TEST_USER_AUTH = os.getenv('USER_AUTH', 'e' * 32)
+TEST_DASH_ENDPOINT = os.getenv('DASH_ENDPOINT', DEFAULT_DASH_ENDPOINT)
+
+
+class VCRGzipSerializer(object):
+    """Custom ZIP serializer for VCR.py."""
+
+    def serialize(self, cassette_dict):
+        # receives a dict, must return a string
+        # there can be binary data inside some of the requests,
+        # so it's impossible to use json for serialization to string
+        cassette_dict = normalize_cassette(cassette_dict)
+        compressed = zlib.compress(pickle.dumps(cassette_dict, protocol=2))
+        return base64.b64encode(compressed).decode('utf8')
+
+    def deserialize(self, cassette_string):
+        # receives a string, must return a dict
+        decoded = base64.b64decode(cassette_string.encode('utf8'))
+        return pickle.loads(zlib.decompress(decoded))
+
+
+def normalize_endpoint(uri, endpoint, default_endpoint):
+    old = endpoint
+    new = default_endpoint
+
+    if old.endswith('/'):
+        old = old[:-1]
+
+    if new.endswith('/'):
+        new = new[:-1]
+
+    return uri.replace(old, new)
+
+
+def normalize_cassette(cassette_dict):
+    """
+    This function normalizes the cassette dict trying to make sure
+    we are always making API requests with the same variables:
+    - project id
+    - endpoint
+    - authentication header
+    """
+    interactions = []
+    for interaction in cassette_dict['interactions']:
+        uri = interaction['request']['uri']
+        uri = uri.replace(TEST_PROJECT_ID, DEFAULT_PROJECT_ID)
+
+        hs_endpoint = TEST_ENDPOINT or HubstorageClient.DEFAULT_ENDPOINT
+        uri = normalize_endpoint(uri, hs_endpoint, DEFAULT_ENDPOINT)
+
+        dash_endpoint = TEST_DASH_ENDPOINT or Connection.DEFAULT_ENDPOINT
+        uri = normalize_endpoint(uri, dash_endpoint, DEFAULT_DASH_ENDPOINT)
+
+        interaction['request']['uri'] = uri
+
+        if 'Authorization' in interaction['request']['headers']:
+            del interaction['request']['headers']['Authorization']
+            interaction['request']['headers']['Authorization'] = (
+                'Basic {}'.format(
+                    base64.b64encode(
+                        '{}:'.format('f' * 32).encode('utf-8')
+                    ).decode('utf-8')
+                )
+            )
+
+        interactions.append(interaction)
+
+    cassette_dict['interactions'] = interactions
+    return cassette_dict
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from scrapinghub.legacy import Connection
 DEFAULT_PROJECT_ID = "2222222"
 DEFAULT_ENDPOINT = 'http://storage.vm.scrapinghub.com'
 DEFAULT_DASH_ENDPOINT = 'http://33.33.33.51:8080/api/'
+DEFAULT_ADMIN_AUTH = 'f' * 32
+DEFAULT_USER_AUTH = 'e' * 32
 
 
 TEST_PROJECT_ID = os.getenv('HS_PROJECT_ID', DEFAULT_PROJECT_ID)
@@ -21,11 +23,11 @@ TEST_SPIDER_NAME = 'hs-test-spider'
 TEST_FRONTIER_SLOT = 'site.com'
 TEST_BOTGROUP = 'python-hubstorage-test'
 TEST_COLLECTION_NAME = "test_collection_123"
-TEST_AUTH = os.getenv('HS_AUTH', 'f' * 32)
+TEST_AUTH = os.getenv('HS_AUTH', DEFAULT_ADMIN_AUTH)
 TEST_ENDPOINT = os.getenv('HS_ENDPOINT', DEFAULT_ENDPOINT)
 TEST_COLLECTION_NAME = "test_collection_123"
-TEST_ADMIN_AUTH = os.getenv('AUTH', 'f' * 32)
-TEST_USER_AUTH = os.getenv('USER_AUTH', 'e' * 32)
+TEST_ADMIN_AUTH = os.getenv('AUTH', DEFAULT_ADMIN_AUTH)
+TEST_USER_AUTH = os.getenv('USER_AUTH', DEFAULT_USER_AUTH)
 TEST_DASH_ENDPOINT = os.getenv('DASH_ENDPOINT', DEFAULT_DASH_ENDPOINT)
 
 
@@ -76,7 +78,7 @@ def normalize_cassette(cassette_dict):
             interaction['request']['headers']['Authorization'] = (
                 'Basic {}'.format(
                     base64.b64encode(
-                        '{}:'.format('f' * 32).encode('utf-8')
+                        '{}:'.format(DEFAULT_ADMIN_AUTH).encode('utf-8')
                     ).decode('utf-8')
                 )
             )

--- a/tests/hubstorage/conftest.py
+++ b/tests/hubstorage/conftest.py
@@ -1,7 +1,4 @@
 import os
-import zlib
-import base64
-import pickle
 
 import vcr
 import pytest
@@ -14,35 +11,18 @@ from scrapinghub.hubstorage.utils import urlpathjoin
 from scrapinghub.hubstorage.serialization import MSGPACK_AVAILABLE
 
 from ..conftest import request_accept_header_matcher
-
-
-TEST_PROJECT_ID = "2222222"
-TEST_SPIDER_NAME = 'hs-test-spider'
-TEST_FRONTIER_SLOT = 'site.com'
-TEST_BOTGROUP = 'python-hubstorage-test'
-TEST_COLLECTION_NAME = "test_collection_123"
-TEST_AUTH = os.getenv('HS_AUTH', 'f' * 32)
-TEST_ENDPOINT = os.getenv('HS_ENDPOINT', 'http://storage.vm.scrapinghub.com')
+from ..conftest import VCRGzipSerializer
+from ..conftest import (
+    TEST_PROJECT_ID,
+    TEST_ENDPOINT,
+    TEST_AUTH,
+    TEST_BOTGROUP,
+    TEST_COLLECTION_NAME,
+    TEST_SPIDER_NAME,
+)
 
 # vcrpy creates the cassetes automatically under VCR_CASSETES_DIR
 VCR_CASSETES_DIR = 'tests/hubstorage/cassetes'
-
-
-class VCRGzipSerializer(object):
-    """Custom ZIP serializer for VCR.py."""
-
-    def serialize(self, cassette_dict):
-        # receives a dict, must return a string
-        # there can be binary data inside some of the requests,
-        # so it's impossible to use json for serialization to string
-        compressed = zlib.compress(pickle.dumps(cassette_dict, protocol=2))
-        return base64.b64encode(compressed).decode('utf8')
-
-    def deserialize(self, cassette_string):
-        # receives a string, must return a dict
-        decoded = base64.b64decode(cassette_string.encode('utf8'))
-        return pickle.loads(zlib.decompress(decoded))
-
 
 my_vcr = vcr.VCR(cassette_library_dir=VCR_CASSETES_DIR, record_mode='once')
 my_vcr.register_serializer('gz', VCRGzipSerializer())

--- a/tests/hubstorage/test_batchuploader.py
+++ b/tests/hubstorage/test_batchuploader.py
@@ -7,7 +7,7 @@ from six.moves import range
 from collections import defaultdict
 
 from scrapinghub.hubstorage import ValueTooLarge
-from .conftest import TEST_SPIDER_NAME, TEST_AUTH
+from ..conftest import TEST_SPIDER_NAME, TEST_AUTH
 from .conftest import start_job
 
 

--- a/tests/hubstorage/test_client.py
+++ b/tests/hubstorage/test_client.py
@@ -4,8 +4,8 @@ Test Client
 from scrapinghub import HubstorageClient
 from scrapinghub.hubstorage.utils import apipoll
 
-from .conftest import TEST_AUTH, TEST_ENDPOINT
-from .conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
+from ..conftest import TEST_AUTH, TEST_ENDPOINT
+from ..conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
 from .conftest import start_job
 
 

--- a/tests/hubstorage/test_collections.py
+++ b/tests/hubstorage/test_collections.py
@@ -8,7 +8,7 @@ import pytest
 from scrapinghub import HubstorageClient
 from six.moves import range
 
-from .conftest import TEST_COLLECTION_NAME
+from ..conftest import TEST_COLLECTION_NAME
 from .testutil import failing_downloader
 
 

--- a/tests/hubstorage/test_frontier.py
+++ b/tests/hubstorage/test_frontier.py
@@ -3,7 +3,7 @@ Test Frontier
 """
 import pytest
 
-from .conftest import TEST_FRONTIER_SLOT
+from ..conftest import TEST_FRONTIER_SLOT
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hubstorage/test_jobq.py
+++ b/tests/hubstorage/test_jobq.py
@@ -9,7 +9,7 @@ from six.moves import range
 from scrapinghub.hubstorage.jobq import DuplicateJobError
 from scrapinghub.hubstorage.utils import apipoll
 
-from .conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
+from ..conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
 from .conftest import hsspiderid
 
 

--- a/tests/hubstorage/test_jobsmeta.py
+++ b/tests/hubstorage/test_jobsmeta.py
@@ -3,7 +3,7 @@ Test job metadata
 
 System tests for operations on stored job metadata
 """
-from .conftest import TEST_SPIDER_NAME
+from ..conftest import TEST_SPIDER_NAME
 from .conftest import start_job
 
 

--- a/tests/hubstorage/test_project.py
+++ b/tests/hubstorage/test_project.py
@@ -9,7 +9,7 @@ from requests.exceptions import HTTPError
 
 from scrapinghub import HubstorageClient
 
-from .conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
+from ..conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
 from .conftest import hsspiderid
 from .conftest import start_job
 from .conftest import set_testbotgroup, unset_testbotgroup

--- a/tests/hubstorage/test_retry.py
+++ b/tests/hubstorage/test_retry.py
@@ -11,8 +11,8 @@ from requests import HTTPError, ConnectionError
 from scrapinghub import HubstorageClient
 from six.moves.http_client import BadStatusLine
 
-from .conftest import TEST_AUTH, TEST_ENDPOINT
-from .conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
+from ..conftest import TEST_AUTH, TEST_ENDPOINT
+from ..conftest import TEST_PROJECT_ID, TEST_SPIDER_NAME
 
 
 GET = responses.GET

--- a/tests/hubstorage/test_system.py
+++ b/tests/hubstorage/test_system.py
@@ -7,8 +7,8 @@ from six.moves import range
 from scrapinghub import HubstorageClient
 from scrapinghub.hubstorage.utils import millitime
 
-from .conftest import TEST_ENDPOINT, TEST_SPIDER_NAME
-from .conftest import TEST_PROJECT_ID, TEST_AUTH
+from ..conftest import TEST_ENDPOINT, TEST_SPIDER_NAME
+from ..conftest import TEST_PROJECT_ID, TEST_AUTH
 from .conftest import start_job
 
 


### PR DESCRIPTION
With these changes, it would be easier to add new cassettes when adding new tests and making calls to HubStorage and Dash APIs.

For example, you can use a dummy Scrapy Cloud project and its deploy API Key to add a new test cassette as following:

```
HS_PROJECT_ID=<project id> HS_AUTH=<api key> AUTH=<api key> USER_AUTH=<api key> HS_ENDPOINT= DASH_ENDPOINT= py.test tests/client/test_collections.py::test_new_case
```

This will use the production servers with the provided credentials and will create a new cassette file at `tests/client/cassettes/test_collections/test_new_case.gz`.

From now on you can execute the test with just:

```
py.test tests/client/test_collections.py::test_new_case
```