### PR TITLE
Switch items API to iteration

### DIFF
--- a/scrapinghub/client/proxy.py
+++ b/scrapinghub/client/proxy.py
@@ -80,7 +80,7 @@ class _ItemsResourceProxy(_Proxy):
         """
         update_kwargs(params, count=count)
         params = self._modify_iter_params(params)
-        return self._origin.list(_key, **params)
+        return self._origin.iter_values(_key, **params)
 
     def flush(self):
         """Flush data from writer threads."""


### PR DESCRIPTION
The current `Items` iteration code requests all crawled data up-front.  For large enough crawls, this results in an indefinite hang from the API as it stalls to return all requests.