### PR TITLE
Update package name for msgpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -r requirements-base.txt
-msgpack-python>=0.4.7
+msgpack>=0.6.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(join(dirname(__file__), 'scrapinghub/VERSION'), 'rb') as f:
     version = f.read().decode('ascii').strip()
 
 is_pypy = '__pypy__' in sys.builtin_module_names
-mpack_required = 'msgpack-pypy>=0.0.2' if is_pypy else 'msgpack-python>=0.4.7'
+mpack_required = 'msgpack-pypy>=0.0.2' if is_pypy else 'msgpack>=0.6.1'
 
 setup(
     name='scrapinghub',


### PR DESCRIPTION
`msgpack-python` was renamed to just `msgpack`, and the old name got deprecated. We have to update the name for msgpack extra as a step toward using msgpack by default in the client.