### PR TITLE
Rename jobs.cancel_jobs -> jobs.cancel

### DIFF
--- a/scrapinghub/client/jobs.py
+++ b/scrapinghub/client/jobs.py
@@ -79,7 +79,7 @@ class Jobs(object):
             params['spider'] = self.spider.name
         return next(self._project.jobq.apiget(('count',), params=params))
 
-    def cancel_jobs(self, keys=None, count=None, **params):
+    def cancel(self, keys=None, count=None, **params):
         """Cancel a list of jobs using the keys provided.
 
         :param keys: (optional) a list of strings containing the job keys in
@@ -94,12 +94,12 @@ class Jobs(object):
 
         - cancel jobs 123 and 321 from project 111 and spiders 222 and 333::
 
-            >>> project.jobs.cancel_jobs(['111/222/123', '111/333/321'])
+            >>> project.jobs.cancel(['111/222/123', '111/333/321'])
             {'count': 2}
 
         - cancel 100 jobs asynchronously::
 
-            >>> project.jobs.cancel_jobs(count=100)
+            >>> project.jobs.cancel(count=100)
             {'count': 100}
         """
         update_kwargs(params, count=count, keys=keys)

--- a/tests/client/test_job.py
+++ b/tests/client/test_job.py
@@ -47,27 +47,27 @@ def test_job_update_tags(spider):
 
 def test_cancel_jobs_validation(spider):
     with pytest.raises(ValueError) as err:
-        spider.jobs.cancel_jobs()
+        spider.jobs.cancel()
 
     assert 'keys or count should be defined' in str(err)
 
     with pytest.raises(ValueError) as err:
-        spider.jobs.cancel_jobs(['2222222/1/1'], count=2)
+        spider.jobs.cancel(['2222222/1/1'], count=2)
 
     assert "keys and count can't be defined simultaneously" in str(err)
 
     with pytest.raises(ValueError) as err:
-        spider.jobs.cancel_jobs(keys="testing")
+        spider.jobs.cancel(keys="testing")
 
     assert 'keys should be a list' in str(err)
 
     with pytest.raises(ValueError) as err:
-        spider.jobs.cancel_jobs(count=[1,2])
+        spider.jobs.cancel(count=[1,2])
 
     assert 'count should be an int' in str(err)
 
     with pytest.raises(ValueError) as err:
-        spider.jobs.cancel_jobs(['2222222/1/1', '2222226/1/1'])
+        spider.jobs.cancel(['2222222/1/1', '2222226/1/1'])
 
     assert 'all keys should belong to project' in str(err)
 
@@ -78,7 +78,7 @@ def test_cancel_jobs(spider):
     assert job1.metadata.get('state') == 'pending'
     assert job2.metadata.get('state') == 'pending'
 
-    output = spider.jobs.cancel_jobs([job1.key, job2.key])
+    output = spider.jobs.cancel([job1.key, job2.key])
 
     assert job1.metadata.get('state') == 'finished'
     assert job2.metadata.get('state') == 'finished'
@@ -90,7 +90,7 @@ def test_cancel_jobs_non_existent(spider):
     assert job1.metadata.get('state') == 'pending'
 
     # Non-existent job
-    output = spider.jobs.cancel_jobs(['%s/1/10000' % job1.project_id])
+    output = spider.jobs.cancel(['%s/1/10000' % job1.project_id])
     assert output == {'count': 0}
     assert job1.metadata.get('state') == 'pending'
 


### PR DESCRIPTION
Let's rename the method to keep consistency with other jobs API.