### PR TITLE
Add nodata example to collections

### DIFF
--- a/scrapinghub/client/collections.py
+++ b/scrapinghub/client/collections.py
@@ -131,11 +131,10 @@ class Collection(object):
         ...     print(elem)
         [{'_key': '002d050ee3ff6192dcbecc4e4b4457d7', 'value': '1447221694537'}]
         
-    - get 1000th item key::
+    - get generator over item keys::
     
-        >>> import itertools
         >>> keys = foo_store.iter(nodata=True, meta=["_key"]))
-        >>> next(itertools.islice(keys, 1000, 1001))
+        >>> next(keys)
         {'_key': '002d050ee3ff6192dcbecc4e4b4457d7'}
 
     - filter by multiple keys, only values for keys that exist will be returned::

--- a/scrapinghub/client/collections.py
+++ b/scrapinghub/client/collections.py
@@ -133,8 +133,9 @@ class Collection(object):
         
     - get 1000th item key::
     
-        >>> keys = foo_store.list(nodata=True, meta=["_key"]))
-        >>> keys[1000]
+        >>> import itertools
+        >>> keys = foo_store.iter(nodata=True, meta=["_key"]))
+        >>> next(itertools.islice(keys, 1000, 1001))
         {'_key': '002d050ee3ff6192dcbecc4e4b4457d7'}
 
     - filter by multiple keys, only values for keys that exist will be returned::

--- a/scrapinghub/client/collections.py
+++ b/scrapinghub/client/collections.py
@@ -125,11 +125,17 @@ class Collection(object):
         >>> foo_store.iter()
         <generator object jldecode at 0x1049eef10>
 
-    - iterate iterate over _key & value pair::
+    - iterate over _key & value pair::
 
         >>> for elem in foo_store.iter(count=1)):
         ...     print(elem)
         [{'_key': '002d050ee3ff6192dcbecc4e4b4457d7', 'value': '1447221694537'}]
+        
+    - get 1000th item key::
+    
+        >>> keys = foo_store.list(nodata=True, meta=["_key"]))
+        >>> keys[1000]
+        {'_key': '002d050ee3ff6192dcbecc4e4b4457d7'}
 
     - filter by multiple keys, only values for keys that exist will be returned::
 


### PR DESCRIPTION
For me it seems the most useful example. In particular, if we want to parallelize collections download we can first fetch all keys then split on batches.
I would also like to add `nodata` to both items and collections`iter()`, but I don't know how to do it.