### PR TITLE
Add retries for more calls #126

### DIFF
--- a/scrapinghub/client/proxy.py
+++ b/scrapinghub/client/proxy.py
@@ -108,8 +108,6 @@ class _DownloadableProxyMixin(object):
         :return: an iterator over elements list.
         :rtype: :class:`collections.Iterable`
         """
-        requests_params = requests_params or {}
-        requests_params.setdefault('is_idempotent', True)
         update_kwargs(apiparams, count=count)
         apiparams = self._modify_iter_params(apiparams)
         drop_key = '_key' not in apiparams.get('meta', [])

--- a/scrapinghub/client/proxy.py
+++ b/scrapinghub/client/proxy.py
@@ -108,6 +108,8 @@ class _DownloadableProxyMixin(object):
         :return: an iterator over elements list.
         :rtype: :class:`collections.Iterable`
         """
+        requests_params = requests_params or {}
+        requests_params.setdefault('is_idempotent', True)
         update_kwargs(apiparams, count=count)
         apiparams = self._modify_iter_params(apiparams)
         drop_key = '_key' not in apiparams.get('meta', [])

--- a/scrapinghub/hubstorage/collectionsrt.py
+++ b/scrapinghub/hubstorage/collectionsrt.py
@@ -63,7 +63,7 @@ class Collections(DownloadableResource):
         return self.apipost((_type, _name, 'deleted'), is_idempotent=True, jl=_keys)
 
     def truncate(self, _name):
-        return self.apipost('delete', params={'name': _name})
+        return self.apipost('delete', params={'name': _name}, is_idempotent=True)
 
     def iter_json(self, _type, _name, requests_params=None, **apiparams):
         return DownloadableResource.iter_json(self, (_type, _name),
@@ -115,7 +115,10 @@ class Collections(DownloadableResource):
         getparams = dict(params)
         try:
             while True:
-                r = next(self.apirequest(path, method=method, params=getparams))
+                r = next(self.apirequest(
+                    path, method=method, params=getparams,
+                    is_idempotent=method=='GET',
+                ))
                 total += r[total_param]
                 next_start = r.get('nextstart')
                 if next_start is None:

--- a/scrapinghub/hubstorage/frontier.py
+++ b/scrapinghub/hubstorage/frontier.py
@@ -59,7 +59,7 @@ class Frontier(ResourceType):
         return self.apiget((frontier, 's', slot, 'q'), params=params)
 
     def delete(self, frontier, slot, ids):
-        self.apipost((frontier, 's', slot, 'q/deleted'), jl=ids)
+        self.apipost((frontier, 's', slot, 'q/deleted'), jl=ids, is_idempotent=True)
 
     def delete_slot(self, frontier, slot):
         self.apidelete((frontier, 's', slot))

--- a/scrapinghub/hubstorage/resourcetype.py
+++ b/scrapinghub/hubstorage/resourcetype.py
@@ -158,6 +158,7 @@ class DownloadableResource(ResourceType):
         requests_params = dict(requests_params or {})
         requests_params.setdefault('method', 'GET')
         requests_params.setdefault('stream', True)
+        requests_params.setdefault('is_idempotent', True)
         requests_params = self._enforce_msgpack(**requests_params)
         for chunk in self._retry(self._iter_content, False, _path,
                                  requests_params, **apiparams):
@@ -168,6 +169,7 @@ class DownloadableResource(ResourceType):
         requests_params = dict(requests_params or {})
         requests_params.setdefault('method', 'GET')
         requests_params.setdefault('stream', True)
+        requests_params.setdefault('is_idempotent', True)
         for line in self._retry(self._iter_lines, True, _path, requests_params,
                                 **apiparams):
             yield line


### PR DESCRIPTION
#126 Didn't know which level of abstraction to pick so went for nearly uppermost (initially went for `_DownloadableProxyMixin.iter()`). Let me know if this has a potential to backfire.
Checked calls within ScrapinghubClient:
`Collection.iter/count/truncate()` [+ retried]
`Logs/Requests/Items.iter()` [+ retried]
`Logs/Requests/Items.stats()` [retied before]
`Items.get()` [retried before]
`Samples.iter()` [retied before], this is the only user of `_ItemsResourceProxy.iter()`
`Jobs.iter/count/summary/iter_last()` [retied before]
`JobMeta.*()` [retied before]
`Collection.get/set()` [retied before]
`Frontiers.iter()` [retied before]
`Frontier.iter()` [retied before]
`FrontierSlot.delete()` [retied before]
`FrontierSlot.q/f.iter()` [retied before]
`FrontierSlot.q.delete(batch_ids)` [+ retried]

Whichever calls that use `legacy.py` are not retried and were not looked into.
Job management (schedule/cancellation/etc.) calls were not looked into (most of them use `legacy.py`).