### PR TITLE
update iter() for better fallback in getting 'meta' argument

### DIFF
--- a/scrapinghub/client/proxy.py
+++ b/scrapinghub/client/proxy.py
@@ -110,7 +110,7 @@ class _DownloadableProxyMixin(object):
         """
         update_kwargs(apiparams, count=count)
         apiparams = self._modify_iter_params(apiparams)
-        drop_key = '_key' not in apiparams.get('meta', [])
+        drop_key = '_key' not in (apiparams.get('meta') or [])
         for entry in self._origin.iter_values(
             _path, requests_params, **apiparams
         ):


### PR DESCRIPTION
Fixes #145 

Here's a condensed version of the code to verify the issue and fix:

```
def iter(**apiparams):
    print(apiparams)
    drop_key = '_key' not in apiparams.get('meta', [])
    print(drop_key)

def iter_fixed(**apiparams):
    print(apiparams)	
    drop_key = '_key' not in (apiparams.get('meta') or [])
    print(drop_key)


>>> iter(meta=None)
{'meta': None}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in iter
TypeError: argument of type 'NoneType' is not iterable

>>> iter_fixed(meta=None)
{'meta': None}
True

>>> iter_fixed()
{}
True
```