### PR TITLE
Bump msgpack version

### DIFF
--- a/scrapinghub/hubstorage/serialization.py
+++ b/scrapinghub/hubstorage/serialization.py
@@ -25,7 +25,7 @@ def jldecode(lineiterable):
 
 
 def mpdecode(iterable):
-    unpacker = Unpacker(encoding='utf8')
+    unpacker = Unpacker()
     for chunk in iterable:
         unpacker.feed(chunk)
         # Each chunk can have none or many objects,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(join(dirname(__file__), 'scrapinghub/VERSION'), 'rb') as f:
     version = f.read().decode('ascii').strip()
 
 is_pypy = '__pypy__' in sys.builtin_module_names
-mpack_required = 'msgpack-pypy>=0.0.2' if is_pypy else 'msgpack>=0.6.1'
+mpack_required = 'msgpack-pypy>=0.0.2' if is_pypy else 'msgpack>=1.0.0'
 
 setup(
     name='scrapinghub',


### PR DESCRIPTION
If you are using the latest msgpack will break when trying to retrieve data

`encoding option is removed. UTF-8 is used always.`

https://github.com/msgpack/msgpack-python#major-breaking-changes-in-msgpack-10

Not sure how the bump and the code change might affect msgpack-pypy

```python
~/.cache/pypoetry/virtualenvs/project-6gE1vKXj-py3.8/lib/python3.8/site-packages/scrapinghub/hubstorage/serialization.py in mpdecode(iterable)
     26 
     27 def mpdecode(iterable):
---> 28     unpacker = Unpacker(encoding='utf8')
     29     for chunk in iterable:
     30         unpacker.feed(chunk)

msgpack/_unpacker.pyx in msgpack._cmsgpack.Unpacker.__init__()

TypeError: __init__() got an unexpected keyword argument 'encoding'

```